### PR TITLE
Feature/#40 add battle phases UI

### DIFF
--- a/features/battle/components/phases/ActionPhase.tsx
+++ b/features/battle/components/phases/ActionPhase.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import type { Card } from "../../../common/types/card";
+import type { ActionLog, CardExchangeDetails, TurnState } from "../../types/player";
+import { canPerformAction } from "../../types/player";
+import { ActionButtons } from "../ActionButtons";
+import { ActionCounter } from "../ActionCounter";
+import { DeckStatus } from "../DeckStatus";
+import { HandArea } from "../HandArea";
+import { OpponentHand } from "../OpponentHand";
+
+export interface ActionPhaseProps {
+  /** 自分の手札 */
+  myHand: Card[];
+  /** 相手の手札枚数 */
+  opponentHandCount: number;
+  /** 自分のターン状態 */
+  myTurnState: TurnState;
+  /** 自分の行動ログ */
+  myActionsLog: ActionLog[];
+  /** 相手の行動ログ */
+  opponentActionsLog: ActionLog[];
+  /** 自分の名前 */
+  myName?: string;
+  /** 相手の名前 */
+  opponentName?: string;
+  /** カード選択時のコールバック */
+  onCardSelect?: (cardId: string) => void;
+  /** 選択中のカードID */
+  selectedCardIds?: string[];
+  /** カード交換クリック時のコールバック */
+  onExchangeClick?: () => void;
+  /** 単語生成クリック時のコールバック */
+  onGenerateClick?: () => void;
+  /** ローディング状態 */
+  isLoading?: boolean;
+  /** クラス名 */
+  className?: string;
+}
+
+/**
+ * アクションフェーズコンポーネント
+ */
+export function ActionPhase({
+  myHand,
+  opponentHandCount,
+  myTurnState,
+  myActionsLog,
+  opponentActionsLog,
+  myName = "あなた",
+  opponentName = "相手",
+  onCardSelect,
+  selectedCardIds = [],
+  onExchangeClick,
+  onGenerateClick,
+  isLoading = false,
+  className = "",
+}: ActionPhaseProps) {
+  const canPerform = canPerformAction(myTurnState);
+
+  return (
+    <div className={`flex flex-col gap-6 ${className}`}>
+      {/* 上部: 相手の手札 */}
+      <div className="flex justify-center">
+        <OpponentHand
+          handCount={opponentHandCount}
+          opponentName={opponentName}
+          deckRemaining={myTurnState.deck_cards_remaining}
+        />
+      </div>
+
+      {/* 中央: 行動ログ表示エリア */}
+      {(myActionsLog.length > 0 || opponentActionsLog.length > 0) && (
+        <div className="relative px-4">
+          {/* 装飾的な背景 */}
+          <div
+            className="absolute inset-0 rounded-lg"
+            style={{
+              background: "linear-gradient(135deg, rgba(139,69,19,0.1), rgba(101,67,33,0.05))",
+              border: "1px solid rgba(139,69,19,0.2)",
+            }}
+          />
+
+          <div className="relative py-3 px-4">
+            <div className="text-sm font-bold mb-2" style={{ color: "#654321" }}>
+              行動ログ
+            </div>
+            <div className="space-y-2 max-h-32 overflow-y-auto">
+              {/* 自分の行動ログ */}
+              {myActionsLog.map((action, index) => {
+                const exchangeDetails =
+                  action.action_type === "card_exchange"
+                    ? (action.details as CardExchangeDetails)
+                    : null;
+                return (
+                  <div
+                    key={index}
+                    className="flex items-center gap-2 text-xs"
+                    style={{ color: "rgba(59,130,246,0.9)" }}
+                  >
+                    <span className="font-semibold">{myName}:</span>
+                    <span>
+                      {action.action_type === "card_exchange"
+                        ? `カード交換 (${exchangeDetails?.discarded_count ?? 0}枚破棄)`
+                        : "単語生成"}
+                    </span>
+                    <span className="text-gray-500">
+                      {new Date(action.timestamp).toLocaleTimeString()}
+                    </span>
+                  </div>
+                );
+              })}
+
+              {/* 相手の行動ログ */}
+              {opponentActionsLog.map((action, index) => {
+                const exchangeDetails =
+                  action.action_type === "card_exchange"
+                    ? (action.details as CardExchangeDetails)
+                    : null;
+                return (
+                  <div
+                    key={index}
+                    className="flex items-center gap-2 text-xs"
+                    style={{ color: "rgba(239,68,68,0.9)" }}
+                  >
+                    <span className="font-semibold">{opponentName}:</span>
+                    <span>
+                      {action.action_type === "card_exchange"
+                        ? `カード交換 (${exchangeDetails?.discarded_count ?? 0}枚破棄)`
+                        : "単語生成"}
+                    </span>
+                    <span className="text-gray-500">
+                      {new Date(action.timestamp).toLocaleTimeString()}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 下部: 自分の手札とアクション */}
+      <div className="flex flex-col gap-4">
+        {/* アクション情報 */}
+        <div className="flex items-center justify-center gap-6 flex-wrap">
+          <ActionCounter turnState={myTurnState} />
+          <DeckStatus turnState={myTurnState} />
+        </div>
+
+        {/* アクションボタン */}
+        <div className="flex justify-center">
+          <ActionButtons
+            canExchange={canPerform}
+            canGenerate={canPerform}
+            onExchangeClick={onExchangeClick}
+            onGenerateClick={onGenerateClick}
+            isLoading={isLoading}
+          />
+        </div>
+
+        {/* 自分の手札 */}
+        <div className="flex justify-center">
+          <HandArea
+            cards={myHand}
+            selectedCardIds={selectedCardIds}
+            multiSelect={true}
+            onCardSelect={onCardSelect}
+            showSimilarity={false}
+            playerName={myName}
+            deckRemaining={myTurnState.deck_cards_remaining}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/battle/components/phases/ActionPhase.tsx
+++ b/features/battle/components/phases/ActionPhase.tsx
@@ -20,6 +20,8 @@ export interface ActionPhaseProps {
   myActionsLog: ActionLog[];
   /** 相手の行動ログ */
   opponentActionsLog: ActionLog[];
+  /** 相手のデッキ残り枚数 */
+  opponentDeckRemaining?: number;
   /** 自分の名前 */
   myName?: string;
   /** 相手の名前 */
@@ -47,6 +49,7 @@ export function ActionPhase({
   myTurnState,
   myActionsLog,
   opponentActionsLog,
+  opponentDeckRemaining,
   myName = "あなた",
   opponentName = "相手",
   onCardSelect,
@@ -65,7 +68,7 @@ export function ActionPhase({
         <OpponentHand
           handCount={opponentHandCount}
           opponentName={opponentName}
-          deckRemaining={myTurnState.deck_cards_remaining}
+          deckRemaining={opponentDeckRemaining}
         />
       </div>
 

--- a/features/battle/components/phases/JudgmentPhase.tsx
+++ b/features/battle/components/phases/JudgmentPhase.tsx
@@ -19,6 +19,8 @@ export interface JudgmentPhaseProps {
   roundResult: RoundResult;
   /** 自分のユーザーID */
   myUserId: string;
+  /** 相手のデッキ残り枚数 */
+  opponentDeckRemaining?: number;
   /** 自分の名前 */
   myName?: string;
   /** 相手の名前 */
@@ -38,6 +40,7 @@ export function JudgmentPhase({
   myTurnState,
   roundResult,
   myUserId,
+  opponentDeckRemaining,
   myName = "あなた",
   opponentName = "相手",
   onAnimationComplete,
@@ -94,7 +97,7 @@ export function JudgmentPhase({
         <OpponentHand
           handCount={opponentHandCount}
           opponentName={opponentName}
-          deckRemaining={myTurnState.deck_cards_remaining}
+          deckRemaining={opponentDeckRemaining}
         />
       </div>
 

--- a/features/battle/components/phases/JudgmentPhase.tsx
+++ b/features/battle/components/phases/JudgmentPhase.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Card } from "../../../common/types/card";
 import type { PointsAwarded, RoundResult } from "../../types/battle";
 import type { TurnState } from "../../types/player";
@@ -49,6 +49,13 @@ export function JudgmentPhase({
   const myPoints = roundResult.points_awarded.find((p) => p.user_id === myUserId);
   const opponentPoints = roundResult.points_awarded.find((p) => p.user_id !== myUserId);
 
+  // onAnimationCompleteの最新の参照をrefに保存
+  const onAnimationCompleteRef = useRef(onAnimationComplete);
+  useEffect(() => {
+    onAnimationCompleteRef.current = onAnimationComplete;
+  }, [onAnimationComplete]);
+
+  // タイマーは一度だけ実行される（依存配列が空）
   useEffect(() => {
     // スコア表示アニメーション（2秒）
     const timer1 = setTimeout(() => {
@@ -58,14 +65,14 @@ export function JudgmentPhase({
     // ポイント付与演出（3秒）
     const timer2 = setTimeout(() => {
       setAnimationPhase("complete");
-      onAnimationComplete?.();
+      onAnimationCompleteRef.current?.();
     }, 5000);
 
     return () => {
       clearTimeout(timer1);
       clearTimeout(timer2);
     };
-  }, [onAnimationComplete]);
+  }, []);
 
   const getPointsDisplayText = (points: PointsAwarded | undefined): string => {
     if (!points) return "+0";

--- a/features/battle/components/phases/JudgmentPhase.tsx
+++ b/features/battle/components/phases/JudgmentPhase.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Card } from "../../../common/types/card";
+import type { PointsAwarded, RoundResult } from "../../types/battle";
+import type { TurnState } from "../../types/player";
+import { getPointReasonText } from "../../utils/score-calculator";
+import { HandArea } from "../HandArea";
+import { OpponentHand } from "../OpponentHand";
+
+export interface JudgmentPhaseProps {
+  /** 自分の手札 */
+  myHand: Card[];
+  /** 相手の手札枚数 */
+  opponentHandCount: number;
+  /** 自分のターン状態 */
+  myTurnState: TurnState;
+  /** ラウンド結果 */
+  roundResult: RoundResult;
+  /** 自分のユーザーID */
+  myUserId: string;
+  /** 自分の名前 */
+  myName?: string;
+  /** 相手の名前 */
+  opponentName?: string;
+  /** アニメーション完了時のコールバック */
+  onAnimationComplete?: () => void;
+  /** クラス名 */
+  className?: string;
+}
+
+/**
+ * 判定フェーズコンポーネント
+ */
+export function JudgmentPhase({
+  myHand,
+  opponentHandCount,
+  myTurnState,
+  roundResult,
+  myUserId,
+  myName = "あなた",
+  opponentName = "相手",
+  onAnimationComplete,
+  className = "",
+}: JudgmentPhaseProps) {
+  const [animationPhase, setAnimationPhase] = useState<"scores" | "points" | "complete">("scores");
+  const mySubmission = roundResult.submissions.find((s) => s.user_id === myUserId);
+  const opponentSubmission = roundResult.submissions.find((s) => s.user_id !== myUserId);
+  const myPoints = roundResult.points_awarded.find((p) => p.user_id === myUserId);
+  const opponentPoints = roundResult.points_awarded.find((p) => p.user_id !== myUserId);
+
+  useEffect(() => {
+    // スコア表示アニメーション（2秒）
+    const timer1 = setTimeout(() => {
+      setAnimationPhase("points");
+    }, 2000);
+
+    // ポイント付与演出（3秒）
+    const timer2 = setTimeout(() => {
+      setAnimationPhase("complete");
+      onAnimationComplete?.();
+    }, 5000);
+
+    return () => {
+      clearTimeout(timer1);
+      clearTimeout(timer2);
+    };
+  }, [onAnimationComplete]);
+
+  const getPointsDisplayText = (points: PointsAwarded | undefined): string => {
+    if (!points) return "+0";
+    if (points.points > 0) return `+${points.points}`;
+    return `${points.points}`;
+  };
+
+  const getPointsColor = (points: PointsAwarded | undefined): string => {
+    if (!points) return "#6B7280";
+    if (points.points > 0) return "#10B981"; // 緑
+    if (points.points < 0) return "#EF4444"; // 赤
+    return "#6B7280"; // グレー
+  };
+
+  return (
+    <div className={`flex flex-col gap-6 ${className}`}>
+      {/* 上部: 相手の手札 */}
+      <div className="flex justify-center">
+        <OpponentHand
+          handCount={opponentHandCount}
+          opponentName={opponentName}
+          deckRemaining={myTurnState.deck_cards_remaining}
+        />
+      </div>
+
+      {/* 中央: 判定結果表示 */}
+      <div className="flex flex-col gap-4">
+        {/* スコア表示 */}
+        {animationPhase !== "complete" && (
+          <div className="flex justify-center gap-8">
+            {/* 自分のスコア */}
+            {mySubmission && (
+              <div
+                className={`px-6 py-4 rounded-lg shadow-lg transition-all ${
+                  animationPhase === "scores" ? "animate-pulse" : ""
+                }`}
+                style={{
+                  background: "linear-gradient(135deg, rgba(59,130,246,0.95), rgba(37,99,235,0.9))",
+                  border: "2px solid rgba(96,165,250,0.7)",
+                  boxShadow: "0 4px 12px rgba(59,130,246,0.4)",
+                }}
+              >
+                <div className="text-center space-y-2">
+                  <div className="text-sm font-bold text-white">{myName}</div>
+                  <div className="text-2xl font-mono font-bold text-white">
+                    {Math.round((mySubmission.final_score + 1) * 50)}点
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* VS表示 */}
+            <div className="flex items-center">
+              <span className="text-3xl font-bold" style={{ color: "rgba(139,69,19,0.8)" }}>
+                VS
+              </span>
+            </div>
+
+            {/* 相手のスコア */}
+            {opponentSubmission && (
+              <div
+                className={`px-6 py-4 rounded-lg shadow-lg transition-all ${
+                  animationPhase === "scores" ? "animate-pulse" : ""
+                }`}
+                style={{
+                  background: "linear-gradient(135deg, rgba(239,68,68,0.95), rgba(185,28,28,0.9))",
+                  border: "2px solid rgba(248,113,113,0.7)",
+                  boxShadow: "0 4px 12px rgba(239,68,68,0.4)",
+                }}
+              >
+                <div className="text-center space-y-2">
+                  <div className="text-sm font-bold text-white">{opponentName}</div>
+                  <div className="text-2xl font-mono font-bold text-white">
+                    {Math.round((opponentSubmission.final_score + 1) * 50)}点
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ポイント付与演出 */}
+        {animationPhase === "points" && (
+          <div className="flex justify-center gap-8">
+            {/* 自分のポイント */}
+            {myPoints && (
+              <div
+                className="px-8 py-6 rounded-lg shadow-lg animate-bounce"
+                style={{
+                  background: `linear-gradient(135deg, ${getPointsColor(myPoints)}CC, ${getPointsColor(myPoints)}99)`,
+                  border: `3px solid ${getPointsColor(myPoints)}`,
+                  boxShadow: `0 8px 24px ${getPointsColor(myPoints)}40`,
+                }}
+              >
+                <div className="text-center space-y-2">
+                  <div className="text-lg font-bold text-white">{myName}</div>
+                  <div className="text-4xl font-mono font-black text-white">
+                    {getPointsDisplayText(myPoints)}
+                  </div>
+                  <div className="text-xs text-white/80">{getPointReasonText(myPoints.reason)}</div>
+                </div>
+              </div>
+            )}
+
+            {/* 相手のポイント */}
+            {opponentPoints && (
+              <div
+                className="px-8 py-6 rounded-lg shadow-lg animate-bounce"
+                style={{
+                  background: `linear-gradient(135deg, ${getPointsColor(opponentPoints)}CC, ${getPointsColor(opponentPoints)}99)`,
+                  border: `3px solid ${getPointsColor(opponentPoints)}`,
+                  boxShadow: `0 8px 24px ${getPointsColor(opponentPoints)}40`,
+                }}
+              >
+                <div className="text-center space-y-2">
+                  <div className="text-lg font-bold text-white">{opponentName}</div>
+                  <div className="text-4xl font-mono font-black text-white">
+                    {getPointsDisplayText(opponentPoints)}
+                  </div>
+                  <div className="text-xs text-white/80">
+                    {getPointReasonText(opponentPoints.reason)}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ラウンド結果表示 */}
+        {animationPhase === "complete" && (
+          <div className="flex justify-center">
+            <div
+              className="px-8 py-6 rounded-lg shadow-lg"
+              style={{
+                background: "linear-gradient(135deg, rgba(139,69,19,0.95), rgba(101,67,33,0.9))",
+                border: "2px solid rgba(218,165,32,0.7)",
+                boxShadow: "0 4px 12px rgba(139,69,19,0.4)",
+              }}
+            >
+              <div className="text-center space-y-2">
+                <div className="text-2xl font-bold text-white">
+                  {roundResult.winner_id === myUserId
+                    ? "🎉 あなたの勝利！"
+                    : roundResult.winner_id
+                      ? `😢 ${opponentName}の勝利`
+                      : "🤝 引き分け"}
+                </div>
+                <div className="text-sm text-amber-100">
+                  ラウンド {roundResult.round_number} 終了
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 下部: 自分の手札 */}
+      <div className="flex justify-center">
+        <HandArea
+          cards={myHand}
+          selectedCardIds={[]}
+          multiSelect={false}
+          showSimilarity={false}
+          playerName={myName}
+          deckRemaining={myTurnState.deck_cards_remaining}
+        />
+      </div>
+    </div>
+  );
+}

--- a/features/battle/components/phases/ResponsePhase.tsx
+++ b/features/battle/components/phases/ResponsePhase.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Handshake, SkipForward } from "lucide-react";
+import type { Card } from "../../../common/types/card";
+import { HandArea } from "../HandArea";
+import { OpponentHand } from "../OpponentHand";
+import type { TurnState } from "../../types/player";
+import type { SubmittedCard } from "../../types/player";
+
+export interface ResponsePhaseProps {
+  /** 自分の手札 */
+  myHand: Card[];
+  /** 相手の手札枚数 */
+  opponentHandCount: number;
+  /** 自分のターン状態 */
+  myTurnState: TurnState;
+  /** 相手の提出カード情報 */
+  opponentSubmission?: SubmittedCard;
+  /** 自分の名前 */
+  myName?: string;
+  /** 相手の名前 */
+  opponentName?: string;
+  /** コールクリック時のコールバック */
+  onCall?: () => void;
+  /** フォールドクリック時のコールバック */
+  onFold?: () => void;
+  /** ローディング状態 */
+  isLoading?: boolean;
+  /** クラス名 */
+  className?: string;
+}
+
+/**
+ * 対応フェーズコンポーネント
+ */
+export function ResponsePhase({
+  myHand,
+  opponentHandCount,
+  myTurnState,
+  opponentSubmission,
+  myName = "あなた",
+  opponentName = "相手",
+  onCall,
+  onFold,
+  isLoading = false,
+  className = "",
+}: ResponsePhaseProps) {
+  const hasVictoryDeclaration = opponentSubmission?.submission_type === "victory_declaration";
+
+  return (
+    <div className={`flex flex-col gap-6 ${className}`}>
+      {/* 上部: 相手の手札 */}
+      <div className="flex justify-center">
+        <OpponentHand
+          handCount={opponentHandCount}
+          opponentName={opponentName}
+          deckRemaining={myTurnState.deck_cards_remaining}
+        />
+      </div>
+
+      {/* 中央: 相手の宣言表示 */}
+      {hasVictoryDeclaration && (
+        <div className="flex justify-center">
+          <div
+            className="px-8 py-6 rounded-lg shadow-lg max-w-md animate-pulse"
+            style={{
+              background: "linear-gradient(135deg, rgba(245,158,11,0.95), rgba(217,119,6,0.9))",
+              border: "3px solid rgba(251,191,36,0.8)",
+              boxShadow: "0 8px 24px rgba(245,158,11,0.5), inset 0 1px 2px rgba(255,255,255,0.3)",
+            }}
+          >
+            <div className="text-center space-y-3">
+              <div className="text-4xl mb-2">👑</div>
+              <div className="text-xl font-bold text-white" style={{ textShadow: "0 2px 4px rgba(0,0,0,0.6)" }}>
+                {opponentName}が勝利宣言をしました！
+              </div>
+              {opponentSubmission && (
+                <div className="mt-4 space-y-2">
+                  <div className="flex justify-between items-center text-sm">
+                    <span className="text-amber-100">類似度</span>
+                    <span className="font-mono font-bold text-white">
+                      {Math.round((opponentSubmission.similarity_score + 1) * 50)}点
+                    </span>
+                  </div>
+                  {opponentSubmission.rarity_bonus > 0 && (
+                    <div className="flex justify-between items-center text-sm">
+                      <span className="text-amber-100">ボーナス</span>
+                      <span className="font-mono font-bold text-yellow-200">
+                        +{Math.round(opponentSubmission.rarity_bonus * 50)}点
+                      </span>
+                    </div>
+                  )}
+                  <div className="flex justify-between items-center text-sm font-semibold pt-2 border-t border-amber-200/30">
+                    <span className="text-amber-100">最終スコア</span>
+                    <span className="font-mono font-bold text-white">
+                      {Math.round((opponentSubmission.final_score + 1) * 50)}点
+                    </span>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 説明テキスト */}
+      {hasVictoryDeclaration && (
+        <div className="text-center px-4">
+          <div
+            className="inline-block px-6 py-3 rounded-lg"
+            style={{
+              background: "linear-gradient(135deg, rgba(239,68,68,0.15), rgba(185,28,28,0.1))",
+              border: "2px solid rgba(239,68,68,0.6)",
+            }}
+          >
+            <p className="text-sm font-semibold text-gray-800">
+              コール: 相手の勝利宣言を受け入れる（勝てば+2点、負ければ-2点）
+            </p>
+            <p className="text-sm font-semibold text-gray-800 mt-1">
+              フォールド: 相手の勝利宣言を認める（相手+1点、自分0点）
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* 下部: 自分の手札と対応ボタン */}
+      <div className="flex flex-col gap-4">
+        {/* 自分の手札 */}
+        <div className="flex justify-center">
+          <HandArea
+            cards={myHand}
+            selectedCardIds={[]}
+            multiSelect={false}
+            showSimilarity={false}
+            playerName={myName}
+            deckRemaining={myTurnState.deck_cards_remaining}
+          />
+        </div>
+
+        {/* 対応ボタン */}
+        {hasVictoryDeclaration && (
+          <div className="flex justify-center gap-4">
+            {/* コールボタン */}
+            <Button
+              onClick={onCall}
+              disabled={isLoading}
+              size="lg"
+              className="flex items-center gap-2 min-w-[180px]"
+              style={{
+                background: "linear-gradient(135deg, rgba(239,68,68,0.95), rgba(185,28,28,0.9))",
+                border: "2px solid rgba(248,113,113,0.7)",
+                color: "white",
+                boxShadow: "0 4px 12px rgba(239,68,68,0.4), inset 0 1px 2px rgba(255,255,255,0.3)",
+              }}
+            >
+              <Handshake className="w-5 h-5" />
+              <span className="font-bold">コール</span>
+            </Button>
+
+            {/* フォールドボタン */}
+            <Button
+              onClick={onFold}
+              disabled={isLoading}
+              size="lg"
+              className="flex items-center gap-2 min-w-[180px]"
+              style={{
+                background: "linear-gradient(135deg, rgba(156,163,175,0.95), rgba(107,114,128,0.9))",
+                border: "2px solid rgba(209,213,219,0.7)",
+                color: "white",
+                boxShadow: "0 4px 12px rgba(156,163,175,0.4), inset 0 1px 2px rgba(255,255,255,0.3)",
+              }}
+            >
+              <SkipForward className="w-5 h-5" />
+              <span className="font-bold">フォールド</span>
+            </Button>
+          </div>
+        )}
+
+        {/* 通常提出の場合のメッセージ */}
+        {!hasVictoryDeclaration && (
+          <div className="text-center py-4">
+            <p className="text-sm text-gray-600">相手が通常提出をしました。判定を待っています...</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/features/battle/components/phases/ResponsePhase.tsx
+++ b/features/battle/components/phases/ResponsePhase.tsx
@@ -3,10 +3,9 @@
 import { Button } from "@/components/ui/button";
 import { Handshake, SkipForward } from "lucide-react";
 import type { Card } from "../../../common/types/card";
+import type { SubmittedCard, TurnState } from "../../types/player";
 import { HandArea } from "../HandArea";
 import { OpponentHand } from "../OpponentHand";
-import type { TurnState } from "../../types/player";
-import type { SubmittedCard } from "../../types/player";
 
 export interface ResponsePhaseProps {
   /** 自分の手札 */
@@ -72,7 +71,10 @@ export function ResponsePhase({
           >
             <div className="text-center space-y-3">
               <div className="text-4xl mb-2">👑</div>
-              <div className="text-xl font-bold text-white" style={{ textShadow: "0 2px 4px rgba(0,0,0,0.6)" }}>
+              <div
+                className="text-xl font-bold text-white"
+                style={{ textShadow: "0 2px 4px rgba(0,0,0,0.6)" }}
+              >
                 {opponentName}が勝利宣言をしました！
               </div>
               {opponentSubmission && (
@@ -165,10 +167,12 @@ export function ResponsePhase({
               size="lg"
               className="flex items-center gap-2 min-w-[180px]"
               style={{
-                background: "linear-gradient(135deg, rgba(156,163,175,0.95), rgba(107,114,128,0.9))",
+                background:
+                  "linear-gradient(135deg, rgba(156,163,175,0.95), rgba(107,114,128,0.9))",
                 border: "2px solid rgba(209,213,219,0.7)",
                 color: "white",
-                boxShadow: "0 4px 12px rgba(156,163,175,0.4), inset 0 1px 2px rgba(255,255,255,0.3)",
+                boxShadow:
+                  "0 4px 12px rgba(156,163,175,0.4), inset 0 1px 2px rgba(255,255,255,0.3)",
               }}
             >
               <SkipForward className="w-5 h-5" />
@@ -187,4 +191,3 @@ export function ResponsePhase({
     </div>
   );
 }
-

--- a/features/battle/components/phases/ResponsePhase.tsx
+++ b/features/battle/components/phases/ResponsePhase.tsx
@@ -16,6 +16,8 @@ export interface ResponsePhaseProps {
   myTurnState: TurnState;
   /** 相手の提出カード情報 */
   opponentSubmission?: SubmittedCard;
+  /** 相手のデッキ残り枚数 */
+  opponentDeckRemaining?: number;
   /** 自分の名前 */
   myName?: string;
   /** 相手の名前 */
@@ -38,6 +40,7 @@ export function ResponsePhase({
   opponentHandCount,
   myTurnState,
   opponentSubmission,
+  opponentDeckRemaining,
   myName = "あなた",
   opponentName = "相手",
   onCall,
@@ -54,7 +57,7 @@ export function ResponsePhase({
         <OpponentHand
           handCount={opponentHandCount}
           opponentName={opponentName}
-          deckRemaining={myTurnState.deck_cards_remaining}
+          deckRemaining={opponentDeckRemaining}
         />
       </div>
 

--- a/features/battle/components/phases/SubmissionPhase.tsx
+++ b/features/battle/components/phases/SubmissionPhase.tsx
@@ -64,10 +64,7 @@ export function SubmissionPhase({
   const similarity = selectedCardId ? similarities[selectedCardId] : undefined;
   const rarityBonus = selectedCardId ? rarityBonuses[selectedCardId] : undefined;
   const finalScore =
-    similarity !== undefined && rarityBonus !== undefined
-      ? Math.min(1.0, similarity + rarityBonus)
-      : similarity;
-
+    similarity !== undefined ? Math.min(1.0, similarity + (rarityBonus ?? 0)) : undefined;
   return (
     <div className={`flex flex-col gap-6 ${className}`}>
       {/* 上部: 相手の手札 */}

--- a/features/battle/components/phases/SubmissionPhase.tsx
+++ b/features/battle/components/phases/SubmissionPhase.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { CheckCircle2, Crown } from "lucide-react";
+import type { Card } from "../../../common/types/card";
+import type { TurnState } from "../../types/player";
+import { HandArea } from "../HandArea";
+import { OpponentHand } from "../OpponentHand";
+
+export interface SubmissionPhaseProps {
+  /** 自分の手札 */
+  myHand: Card[];
+  /** 相手の手札枚数 */
+  opponentHandCount: number;
+  /** 自分のターン状態 */
+  myTurnState: TurnState;
+  /** お題カードのテキスト */
+  fieldCardText: string;
+  /** 選択中のカードID */
+  selectedCardId?: string;
+  /** カードごとの類似度マップ */
+  similarities?: Record<string, number>;
+  /** カードごとのレアリティボーナスマップ */
+  rarityBonuses?: Record<string, number>;
+  /** カードごとのデッキカードフラグマップ */
+  isDeckCards?: Record<string, boolean>;
+  /** 自分の名前 */
+  myName?: string;
+  /** 相手の名前 */
+  opponentName?: string;
+  /** カード選択時のコールバック */
+  onCardSelect?: (cardId: string) => void;
+  /** 通常提出クリック時のコールバック */
+  onNormalSubmit?: (cardId: string) => void;
+  /** 勝利宣言クリック時のコールバック */
+  onVictoryDeclaration?: (cardId: string) => void;
+  /** ローディング状態 */
+  isLoading?: boolean;
+  /** クラス名 */
+  className?: string;
+}
+
+/**
+ * 提出フェーズコンポーネント
+ */
+export function SubmissionPhase({
+  myHand,
+  opponentHandCount,
+  myTurnState,
+  fieldCardText,
+  selectedCardId,
+  similarities = {},
+  rarityBonuses = {},
+  isDeckCards = {},
+  myName = "あなた",
+  opponentName = "相手",
+  onCardSelect,
+  onNormalSubmit,
+  onVictoryDeclaration,
+  isLoading = false,
+  className = "",
+}: SubmissionPhaseProps) {
+  const selectedCard = selectedCardId ? myHand.find((c) => c.id === selectedCardId) : undefined;
+  const similarity = selectedCardId ? similarities[selectedCardId] : undefined;
+  const rarityBonus = selectedCardId ? rarityBonuses[selectedCardId] : undefined;
+  const finalScore =
+    similarity !== undefined && rarityBonus !== undefined
+      ? Math.min(1.0, similarity + rarityBonus)
+      : similarity;
+
+  return (
+    <div className={`flex flex-col gap-6 ${className}`}>
+      {/* 上部: 相手の手札 */}
+      <div className="flex justify-center">
+        <OpponentHand
+          handCount={opponentHandCount}
+          opponentName={opponentName}
+          deckRemaining={myTurnState.deck_cards_remaining}
+        />
+      </div>
+
+      {/* 中央: お題カード表示エリア */}
+      <div className="flex justify-center">
+        <div
+          className="px-6 py-4 rounded-lg shadow-lg"
+          style={{
+            background: "linear-gradient(135deg, rgba(218,165,32,0.95), rgba(184,134,11,0.9))",
+            border: "2px solid rgba(255,215,0,0.7)",
+            boxShadow: "0 4px 12px rgba(218,165,32,0.4), inset 0 1px 2px rgba(255,255,255,0.3)",
+          }}
+        >
+          <div className="text-center">
+            <div
+              className="text-sm font-bold mb-2"
+              style={{ color: "#FFF5E6", textShadow: "0 1px 3px rgba(0,0,0,0.6)" }}
+            >
+              お題カード
+            </div>
+            <div
+              className="text-3xl font-black"
+              style={{
+                writingMode: "vertical-rl",
+                textOrientation: "upright",
+                letterSpacing: "0.15em",
+                color: "#FFF5E6",
+                textShadow: "0 2px 4px rgba(0,0,0,0.7), 0 0 8px rgba(218,165,32,0.4)",
+              }}
+            >
+              {fieldCardText}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 類似度プレビュー */}
+      {selectedCard && similarity !== undefined && (
+        <div className="flex justify-center">
+          <div
+            className="px-6 py-4 rounded-lg shadow-md max-w-md"
+            style={{
+              background: "linear-gradient(135deg, rgba(34,197,94,0.15), rgba(22,163,74,0.1))",
+              border: "2px solid rgba(74,222,128,0.7)",
+              boxShadow: "0 2px 8px rgba(34,197,94,0.3)",
+            }}
+          >
+            <div className="space-y-2">
+              <div className="text-sm font-bold mb-3" style={{ color: "#16A34A" }}>
+                スコアプレビュー
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-sm text-gray-700">類似度</span>
+                <span className="font-mono font-bold text-lg">
+                  {Math.round((similarity + 1) * 50)}点
+                </span>
+              </div>
+              {rarityBonus !== undefined && rarityBonus > 0 && (
+                <>
+                  <div className="flex justify-between items-center">
+                    <span className="text-sm text-gray-700">レアリティボーナス</span>
+                    <span className="font-mono font-bold text-lg text-yellow-600">
+                      +{Math.round(rarityBonus * 50)}点
+                    </span>
+                  </div>
+                  <div className="h-px bg-gray-300 my-2" />
+                  <div className="flex justify-between items-center">
+                    <span className="text-sm font-semibold text-gray-800">最終スコア</span>
+                    <span className="font-mono font-bold text-xl text-green-600">
+                      {Math.round(((finalScore ?? 0) + 1) * 50)}点
+                    </span>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 下部: 自分の手札と提出ボタン */}
+      <div className="flex flex-col gap-4">
+        {/* 自分の手札 */}
+        <div className="flex justify-center">
+          <HandArea
+            cards={myHand}
+            selectedCardIds={selectedCardId ? [selectedCardId] : []}
+            multiSelect={false}
+            onCardSelect={onCardSelect}
+            showSimilarity={true}
+            playerName={myName}
+            deckRemaining={myTurnState.deck_cards_remaining}
+            similarities={similarities}
+            rarityBonuses={rarityBonuses}
+            isDeckCards={isDeckCards}
+          />
+        </div>
+
+        {/* 提出ボタン */}
+        {selectedCard && (
+          <div className="flex justify-center gap-4">
+            {/* 通常提出ボタン */}
+            <Button
+              onClick={() => onNormalSubmit?.(selectedCardId!)}
+              disabled={isLoading || !selectedCardId}
+              size="lg"
+              className="flex items-center gap-2 min-w-[180px]"
+              style={{
+                background: "linear-gradient(135deg, rgba(34,197,94,0.95), rgba(22,163,74,0.9))",
+                border: "2px solid rgba(74,222,128,0.7)",
+                color: "white",
+                boxShadow: "0 4px 12px rgba(34,197,94,0.4), inset 0 1px 2px rgba(255,255,255,0.3)",
+              }}
+            >
+              <CheckCircle2 className="w-5 h-5" />
+              <span className="font-bold">通常提出</span>
+            </Button>
+
+            {/* 勝利宣言ボタン */}
+            <Button
+              onClick={() => onVictoryDeclaration?.(selectedCardId!)}
+              disabled={isLoading || !selectedCardId}
+              size="lg"
+              className="flex items-center gap-2 min-w-[180px]"
+              style={{
+                background: "linear-gradient(135deg, rgba(245,158,11,0.95), rgba(217,119,6,0.9))",
+                border: "2px solid rgba(251,191,36,0.7)",
+                color: "white",
+                boxShadow: "0 4px 12px rgba(245,158,11,0.4), inset 0 1px 2px rgba(255,255,255,0.3)",
+              }}
+            >
+              <Crown className="w-5 h-5" />
+              <span className="font-bold">勝利宣言</span>
+            </Button>
+          </div>
+        )}
+
+        {/* 選択されていない場合のメッセージ */}
+        {!selectedCard && (
+          <div className="text-center py-4">
+            <p className="text-sm text-gray-600">提出するカードを選択してください</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/features/battle/components/phases/SubmissionPhase.tsx
+++ b/features/battle/components/phases/SubmissionPhase.tsx
@@ -24,6 +24,8 @@ export interface SubmissionPhaseProps {
   rarityBonuses?: Record<string, number>;
   /** カードごとのデッキカードフラグマップ */
   isDeckCards?: Record<string, boolean>;
+  /** 相手のデッキ残り枚数 */
+  opponentDeckRemaining?: number;
   /** 自分の名前 */
   myName?: string;
   /** 相手の名前 */
@@ -52,6 +54,7 @@ export function SubmissionPhase({
   similarities = {},
   rarityBonuses = {},
   isDeckCards = {},
+  opponentDeckRemaining,
   myName = "あなた",
   opponentName = "相手",
   onCardSelect,
@@ -72,7 +75,7 @@ export function SubmissionPhase({
         <OpponentHand
           handCount={opponentHandCount}
           opponentName={opponentName}
-          deckRemaining={myTurnState.deck_cards_remaining}
+          deckRemaining={opponentDeckRemaining}
         />
       </div>
 


### PR DESCRIPTION
# Pull Request

## Issue

Closes #40 

## 概要

<!-- このPRで何を実装/修正したかを簡潔に説明してください -->

- 各フェーズごとのUIコンポーネントを作成

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- [x] 新機能の追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テストの追加/修正
- [ ] その他:

## 変更箇所

<!-- どの部分を変更したかチェックしてください -->

- [x] フロントエンド
- [ ] バックエンド
- [ ] データベース
- [ ] 設定ファイル
- [ ] ドキュメント

## 注意事項

<!-- レビュー時に注意してほしい点や、デプロイ時の注意点があれば記載してください -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * バトル画面に4つの新しいフェーズUIを追加
    * アクションフェーズ：対戦相手の残りデッキ表示、行動ログ表示（プレイヤー別・交換詳細含む）、マルチセレクト対応の手札操作、アクションカウンターとデッキ状況を表示
    * 提出フェーズ：カード選択とスコアプレビュー、通常提出／勝利宣言ボタン
    * 判定フェーズ：スコア表示と段階的アニメーション（スコア→ポイント→完了）
    * 応答フェーズ：勝利宣言へのコール／フォルド選択、宣言内容のスコア詳細表示
* **改善**
  * フェーズ間でプレイヤー名とデッキ残数表示を統一して強化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->