### PR TITLE
2人用対戦ページを作成

### DIFF
--- a/convex/card.ts
+++ b/convex/card.ts
@@ -104,6 +104,35 @@ export const getCardsByDetails = query({
   },
 });
 
+/**
+ * カードIDの配列からカード情報を一括取得
+ */
+export const getCardsByIds = query({
+  args: {
+    cardIds: v.array(v.id("card")),
+  },
+  handler: async (ctx, { cardIds }) => {
+    if (cardIds.length === 0) {
+      return [];
+    }
+
+    // 並列でカードを取得
+    const cards = await Promise.all(
+      cardIds.map(async (cardId) => {
+        try {
+          const card = await ctx.db.get(cardId);
+          return card;
+        } catch (error) {
+          console.error(`getCardsByIds - error fetching card ${cardId}:`, error);
+          return null;
+        }
+      })
+    );
+
+    return cards.filter((card): card is NonNullable<typeof card> => card !== null);
+  },
+});
+
 //ユーザの所持カードを取得する
 export const getUserCards = query({
   handler: async (ctx) => {

--- a/features/battle/components/BattleContainer.tsx
+++ b/features/battle/components/BattleContainer.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+import type { Id } from "../../../convex/_generated/dataModel";
+import { useBattle } from "../hooks/useBattle";
+import { usePhaseTimer } from "../hooks/usePhaseTimer";
+import { BattleHeader } from "./BattleHeader";
+import { FieldCard } from "./FieldCard";
+import { BattleResultModal } from "./modals/BattleResultModal";
+import { CardExchangeModal } from "./modals/CardExchangeModal";
+import { RoundResultModal } from "./modals/RoundResultModal";
+import { WordGenerationModal } from "./modals/WordGenerationModal";
+import { ActionPhase } from "./phases/ActionPhase";
+import { JudgmentPhase } from "./phases/JudgmentPhase";
+import { ResponsePhase } from "./phases/ResponsePhase";
+import { SubmissionPhase } from "./phases/SubmissionPhase";
+
+export interface BattleContainerProps {
+  /** バトルID */
+  battleId: Id<"battle">;
+  /** 自分のユーザーID */
+  myUserId: Id<"user">;
+}
+
+/**
+ * バトル全体のコンテナコンポーネント
+ */
+export function BattleContainer({ battleId, myUserId }: BattleContainerProps) {
+  const router = useRouter();
+  const [selectedCardId, setSelectedCardId] = useState<string | undefined>();
+  const [selectedCardIds, setSelectedCardIds] = useState<string[]>([]);
+  const [isExchangeModalOpen, setIsExchangeModalOpen] = useState(false);
+  const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
+  const [isRoundResultModalOpen, setIsRoundResultModalOpen] = useState(false);
+  const [isBattleResultModalOpen, setIsBattleResultModalOpen] = useState(false);
+
+  const {
+    battle,
+    isLoading,
+    myPlayer,
+    opponentPlayer,
+    myHand,
+    fieldCardText,
+    isDeckCards,
+    rarityBonuses,
+    exchangeCards,
+    generateWord,
+    submitCard,
+    respondToDeclaration,
+    isActionLoading,
+  } = useBattle({ battleId, myUserId });
+
+  // フェーズタイマー
+  const timeRemaining = usePhaseTimer(
+    battle?.phase_start_time ?? Date.now(),
+    battle?.current_phase ?? "field_card_presentation",
+    () => {
+      // タイムアウト時の処理（自動処理など）
+      console.log("Phase timeout");
+    }
+  );
+
+  // モーダルハンドラー
+  const handleExchangeClick = useCallback(() => {
+    setIsExchangeModalOpen(true);
+  }, []);
+
+  const handleGenerateClick = useCallback(() => {
+    setIsGenerateModalOpen(true);
+  }, []);
+
+  const handleExchange = useCallback(
+    async (discardIds: string[], drawSource: "deck" | "pool") => {
+      await exchangeCards(discardIds, drawSource);
+      setIsExchangeModalOpen(false);
+      setSelectedCardIds([]);
+    },
+    [exchangeCards]
+  );
+
+  const handleGenerate = useCallback(
+    async (positiveCards: string[], negativeCards: string[]) => {
+      await generateWord(positiveCards, negativeCards);
+      setIsGenerateModalOpen(false);
+    },
+    [generateWord]
+  );
+
+  const handleNormalSubmit = useCallback(
+    async (cardId: string) => {
+      await submitCard(cardId, "normal");
+      setSelectedCardId(undefined);
+    },
+    [submitCard]
+  );
+
+  const handleVictoryDeclaration = useCallback(
+    async (cardId: string) => {
+      await submitCard(cardId, "victory_declaration");
+      setSelectedCardId(undefined);
+    },
+    [submitCard]
+  );
+
+  const handleCall = useCallback(async () => {
+    await respondToDeclaration("call");
+  }, [respondToDeclaration]);
+
+  const handleFold = useCallback(async () => {
+    await respondToDeclaration("fold");
+  }, [respondToDeclaration]);
+
+  // ラウンド結果モーダルの処理
+  const latestRoundResult = battle?.round_results[battle.round_results.length - 1];
+  const shouldShowRoundResult =
+    battle?.current_phase === "point_calculation" && latestRoundResult && !isRoundResultModalOpen;
+
+  if (shouldShowRoundResult) {
+    setIsRoundResultModalOpen(true);
+  }
+
+  // バトル終了チェック
+  const shouldShowBattleResult = battle?.game_status === "finished" && !isBattleResultModalOpen;
+
+  if (shouldShowBattleResult) {
+    setIsBattleResultModalOpen(true);
+  }
+
+  // ローディング状態
+  if (isLoading || !battle || !myPlayer || !opponentPlayer) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="text-xl mb-4">読み込み中...</div>
+          <div className="w-16 h-16 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto" />
+        </div>
+      </div>
+    );
+  }
+
+  const currentPhase = battle.current_phase;
+  const myScore = myPlayer.score;
+  const opponentScore = opponentPlayer.score;
+
+  // 類似度マップ（提出フェーズで使用）
+  // TODO: 実際の類似度計算を実装
+  const similarities: Record<string, number> = {};
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-amber-50 to-amber-100">
+      <BattleHeader
+        currentPhase={currentPhase}
+        timeRemaining={timeRemaining}
+        myScore={myScore}
+        opponentScore={opponentScore}
+        currentRound={battle.current_round}
+      />
+
+      <main className="container mx-auto px-4 py-6 max-w-7xl">
+        {/* フェーズ別UI */}
+        {currentPhase === "field_card_presentation" && (
+          <div className="flex items-center justify-center min-h-[60vh]">
+            <FieldCard word={fieldCardText} />
+          </div>
+        )}
+
+        {currentPhase === "player_action" && (
+          <ActionPhase
+            myHand={myHand}
+            opponentHandCount={opponentPlayer.hand.length}
+            myTurnState={myPlayer.turn_state}
+            myActionsLog={myPlayer.turn_state.actions_log}
+            opponentActionsLog={opponentPlayer.turn_state.actions_log}
+            opponentDeckRemaining={opponentPlayer.turn_state.deck_cards_remaining}
+            selectedCardIds={selectedCardIds}
+            onCardSelect={(cardId) => {
+              if (selectedCardIds.includes(cardId)) {
+                setSelectedCardIds(selectedCardIds.filter((id) => id !== cardId));
+              } else {
+                setSelectedCardIds([...selectedCardIds, cardId]);
+              }
+            }}
+            onExchangeClick={handleExchangeClick}
+            onGenerateClick={handleGenerateClick}
+            isLoading={isActionLoading}
+          />
+        )}
+
+        {currentPhase === "word_submission" && (
+          <SubmissionPhase
+            myHand={myHand}
+            opponentHandCount={opponentPlayer.hand.length}
+            myTurnState={myPlayer.turn_state}
+            fieldCardText={fieldCardText}
+            selectedCardId={selectedCardId}
+            similarities={similarities}
+            rarityBonuses={rarityBonuses}
+            isDeckCards={isDeckCards}
+            opponentDeckRemaining={opponentPlayer.turn_state.deck_cards_remaining}
+            onCardSelect={setSelectedCardId}
+            onNormalSubmit={selectedCardId ? () => handleNormalSubmit(selectedCardId) : undefined}
+            onVictoryDeclaration={
+              selectedCardId ? () => handleVictoryDeclaration(selectedCardId) : undefined
+            }
+            isLoading={isActionLoading}
+          />
+        )}
+
+        {currentPhase === "response" && (
+          <ResponsePhase
+            myHand={myHand}
+            opponentHandCount={opponentPlayer.hand.length}
+            myTurnState={myPlayer.turn_state}
+            opponentSubmission={opponentPlayer.submitted_card}
+            opponentDeckRemaining={opponentPlayer.turn_state.deck_cards_remaining}
+            onCall={handleCall}
+            onFold={handleFold}
+            isLoading={isActionLoading}
+          />
+        )}
+
+        {currentPhase === "point_calculation" && latestRoundResult && (
+          <JudgmentPhase
+            myHand={myHand}
+            opponentHandCount={opponentPlayer.hand.length}
+            myTurnState={myPlayer.turn_state}
+            roundResult={latestRoundResult}
+            myUserId={myUserId}
+            opponentDeckRemaining={opponentPlayer.turn_state.deck_cards_remaining}
+          />
+        )}
+      </main>
+
+      {/* モーダル */}
+      <CardExchangeModal
+        isOpen={isExchangeModalOpen}
+        onClose={() => {
+          setIsExchangeModalOpen(false);
+          setSelectedCardIds([]);
+        }}
+        cards={myHand}
+        deckRemaining={myPlayer.turn_state.deck_cards_remaining}
+        onExchange={handleExchange}
+        isLoading={isActionLoading}
+      />
+
+      <WordGenerationModal
+        isOpen={isGenerateModalOpen}
+        onClose={() => setIsGenerateModalOpen(false)}
+        cards={myHand}
+        onGenerate={handleGenerate}
+        isLoading={isActionLoading}
+      />
+
+      {latestRoundResult && (
+        <RoundResultModal
+          isOpen={isRoundResultModalOpen}
+          onClose={() => setIsRoundResultModalOpen(false)}
+          roundResult={latestRoundResult}
+          myUserId={myUserId}
+        />
+      )}
+
+      {battle && (
+        <BattleResultModal
+          isOpen={isBattleResultModalOpen}
+          onClose={() => setIsBattleResultModalOpen(false)}
+          battle={battle}
+          myUserId={myUserId}
+          onGoHome={() => router.push("/")}
+        />
+      )}
+    </div>
+  );
+}

--- a/features/battle/components/BattleContainer.tsx
+++ b/features/battle/components/BattleContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Id } from "../../../convex/_generated/dataModel";
 import { useBattle } from "../hooks/useBattle";
 import { usePhaseTimer } from "../hooks/usePhaseTimer";
@@ -111,21 +111,26 @@ export function BattleContainer({ battleId, myUserId }: BattleContainerProps) {
     await respondToDeclaration("fold");
   }, [respondToDeclaration]);
 
-  // ラウンド結果モーダルの処理
-  const latestRoundResult = battle?.round_results[battle.round_results.length - 1];
-  const shouldShowRoundResult =
-    battle?.current_phase === "point_calculation" && latestRoundResult && !isRoundResultModalOpen;
+  // ラウンド結果の安全な取得
+  const roundResults = battle?.round_results;
+  const latestRoundResult = roundResults?.[roundResults.length - 1];
 
-  if (shouldShowRoundResult) {
-    setIsRoundResultModalOpen(true);
-  }
+  // ラウンド結果モーダルの表示制御（useEffectで処理）
+  useEffect(() => {
+    const shouldShow =
+      battle?.current_phase === "point_calculation" && latestRoundResult && !isRoundResultModalOpen;
+    if (shouldShow) {
+      setIsRoundResultModalOpen(true);
+    }
+  }, [battle?.current_phase, latestRoundResult, isRoundResultModalOpen]);
 
-  // バトル終了チェック
-  const shouldShowBattleResult = battle?.game_status === "finished" && !isBattleResultModalOpen;
-
-  if (shouldShowBattleResult) {
-    setIsBattleResultModalOpen(true);
-  }
+  // バトル終了モーダルの表示制御（useEffectで処理）
+  useEffect(() => {
+    const shouldShow = battle?.game_status === "finished" && !isBattleResultModalOpen;
+    if (shouldShow) {
+      setIsBattleResultModalOpen(true);
+    }
+  }, [battle?.game_status, isBattleResultModalOpen]);
 
   // ローディング状態
   if (isLoading || !battle || !myPlayer || !opponentPlayer) {

--- a/features/battle/hooks/useBattle.ts
+++ b/features/battle/hooks/useBattle.ts
@@ -1,0 +1,264 @@
+"use client";
+
+import { useMutation, useQuery } from "convex/react";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { api } from "../../../convex/_generated/api";
+import type { Doc, Id } from "../../../convex/_generated/dataModel";
+import type { Card } from "../../common/types/card";
+import type { Battle } from "../types/battle";
+import {
+  convertBattleDocToBattle,
+  createCardMap,
+  createDeckCardMap,
+  createRarityBonusMap,
+  getFieldCardText,
+  getMyPlayerState,
+  getOpponentPlayerState,
+  getPlayerHandCards,
+  type PreparedBattleData,
+} from "../utils/battle-data";
+
+export interface UseBattleOptions {
+  battleId: Id<"battle">;
+  myUserId: Id<"user">;
+}
+
+export interface UseBattleReturn {
+  /** バトル情報 */
+  battle: Battle | undefined;
+  /** ローディング状態 */
+  isLoading: boolean;
+  /** エラー */
+  error: Error | null;
+  /** 自分のプレイヤー状態 */
+  myPlayer: ReturnType<typeof getMyPlayerState> | undefined;
+  /** 相手のプレイヤー状態 */
+  opponentPlayer: ReturnType<typeof getOpponentPlayerState> | undefined;
+  /** 自分の手札 */
+  myHand: Card[];
+  /** お題カードのテキスト */
+  fieldCardText: string;
+  /** デッキカード判定マップ */
+  isDeckCards: Record<string, boolean>;
+  /** レアリティボーナスマップ */
+  rarityBonuses: Record<string, number>;
+  /** カードマップ */
+  cardMap: Map<Id<"card">, Doc<"card">>;
+  /** カード交換 */
+  exchangeCards: (discardIds: string[], drawSource: "deck" | "pool") => Promise<void>;
+  /** 単語生成 */
+  generateWord: (positiveCards: string[], negativeCards: string[]) => Promise<void>;
+  /** カード提出 */
+  submitCard: (cardId: string, submissionType: "normal" | "victory_declaration") => Promise<void>;
+  /** 勝利宣言への応答 */
+  respondToDeclaration: (responseType: "call" | "fold") => Promise<void>;
+  /** ローディング状態（アクション実行中） */
+  isActionLoading: boolean;
+}
+
+/**
+ * バトル状態管理フック
+ */
+export function useBattle({ battleId, myUserId }: UseBattleOptions): UseBattleReturn {
+  const [isActionLoading, setIsActionLoading] = useState(false);
+
+  // バトル情報を取得
+  const battleDoc = useQuery(api.battle.getBattle, { battleId });
+  const user = useQuery(api.user.getMyUser);
+
+  // Convexのドキュメントをフロントエンドの型に変換
+  const battle = useMemo(() => {
+    if (!battleDoc) return undefined;
+    return convertBattleDocToBattle(battleDoc);
+  }, [battleDoc]);
+
+  // ミューテーション
+  const exchangeCardsMutation = useMutation(api.battle.exchangeCards);
+  const generateWordMutation = useMutation(api.battle.generateWord);
+  const submitCardMutation = useMutation(api.battle.submitCard);
+  const respondToDeclarationMutation = useMutation(api.battle.respondToDeclaration);
+
+  // カード情報を取得（手札とお題カード）
+  const cardIds = useMemo(() => {
+    if (!battle) return [];
+    const ids = new Set<Id<"card">>();
+    // お題カード
+    ids.add(battle.field_card_id);
+    // 全プレイヤーの手札
+    for (const player of battle.players) {
+      for (const cardId of player.hand) {
+        ids.add(cardId);
+      }
+    }
+    return Array.from(ids);
+  }, [battle]);
+
+  // カード情報を一括取得
+  const cards = useQuery(api.card.getCardsByIds, cardIds.length > 0 ? { cardIds } : "skip");
+
+  // カード情報をマップに変換
+  const cardMap = useMemo(() => {
+    if (!cards) return new Map<Id<"card">, Doc<"card">>();
+    return createCardMap(cards);
+  }, [cards]);
+
+  // 自分のプレイヤー状態を取得（デッキカード取得に必要）
+  const myPlayerState = useMemo(() => {
+    if (!battle) return undefined;
+    return getMyPlayerState(battle, myUserId);
+  }, [battle, myUserId]);
+
+  // デッキカード情報を取得
+  const deckCardIds = useQuery(
+    api.deck.getUserDeckCards,
+    battle && myPlayerState ? { userId: myUserId, deckId: myPlayerState.deck_ref } : "skip"
+  );
+
+  // データを準備
+  const preparedData = useMemo<PreparedBattleData | null>(() => {
+    if (!battle || !cardMap.size) return null;
+
+    const myPlayer = getMyPlayerState(battle, myUserId);
+    const opponentPlayer = getOpponentPlayerState(battle, myUserId);
+
+    if (!myPlayer || !opponentPlayer) return null;
+
+    const myHand = getPlayerHandCards(myPlayer, cardMap);
+    const fieldCardText = getFieldCardText(battle.field_card_id, cardMap);
+
+    // デッキカード判定
+    const deckCardIdArray: Id<"card">[] =
+      deckCardIds
+        ?.filter((dc): dc is NonNullable<typeof dc> => dc !== null)
+        .map((dc) => dc.card._id)
+        .filter((id): id is Id<"card"> => id !== undefined) ?? [];
+    const isDeckCards = createDeckCardMap(myPlayer.hand, deckCardIdArray);
+    const rarityBonuses = createRarityBonusMap(myPlayer.hand, cardMap, isDeckCards);
+
+    return {
+      myPlayer,
+      opponentPlayer,
+      myHand,
+      fieldCardText,
+      cardMap,
+      isDeckCards,
+      rarityBonuses,
+    };
+  }, [battle, cardMap, myUserId, deckCardIds]);
+
+  // カード交換
+  const exchangeCards = async (discardIds: string[], drawSource: "deck" | "pool") => {
+    if (!user?._id) {
+      toast.error("ユーザー情報が取得できません");
+      return;
+    }
+
+    setIsActionLoading(true);
+    try {
+      await exchangeCardsMutation({
+        battle_id: battleId,
+        user_id: user._id,
+        discard_card_ids: discardIds as Id<"card">[],
+        draw_source: drawSource,
+      });
+      toast.success("カードを交換しました");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "カード交換に失敗しました");
+      throw error;
+    } finally {
+      setIsActionLoading(false);
+    }
+  };
+
+  // 単語生成
+  const generateWord = async (positiveCards: string[], negativeCards: string[]) => {
+    if (!user?._id) {
+      toast.error("ユーザー情報が取得できません");
+      return;
+    }
+
+    setIsActionLoading(true);
+    try {
+      await generateWordMutation({
+        battle_id: battleId,
+        user_id: user._id,
+        positive_cards: positiveCards as Id<"card">[],
+        negative_cards: negativeCards as Id<"card">[],
+      });
+      toast.success("単語を生成しました");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "単語生成に失敗しました");
+      throw error;
+    } finally {
+      setIsActionLoading(false);
+    }
+  };
+
+  // カード提出
+  const submitCard = async (cardId: string, submissionType: "normal" | "victory_declaration") => {
+    if (!user?._id) {
+      toast.error("ユーザー情報が取得できません");
+      return;
+    }
+
+    setIsActionLoading(true);
+    try {
+      await submitCardMutation({
+        battle_id: battleId,
+        user_id: user._id,
+        card_id: cardId as Id<"card">,
+        submission_type: submissionType,
+      });
+      toast.success(
+        submissionType === "victory_declaration" ? "勝利宣言を提出しました" : "カードを提出しました"
+      );
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "カード提出に失敗しました");
+      throw error;
+    } finally {
+      setIsActionLoading(false);
+    }
+  };
+
+  // 勝利宣言への応答
+  const respondToDeclaration = async (responseType: "call" | "fold") => {
+    if (!user?._id) {
+      toast.error("ユーザー情報が取得できません");
+      return;
+    }
+
+    setIsActionLoading(true);
+    try {
+      await respondToDeclarationMutation({
+        battle_id: battleId,
+        user_id: user._id,
+        response_type: responseType,
+      });
+      toast.success(responseType === "call" ? "コールしました" : "フォールドしました");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "応答に失敗しました");
+      throw error;
+    } finally {
+      setIsActionLoading(false);
+    }
+  };
+
+  return {
+    battle,
+    isLoading: battle === undefined,
+    error: null, // TODO: エラーハンドリングを追加
+    myPlayer: preparedData?.myPlayer,
+    opponentPlayer: preparedData?.opponentPlayer,
+    myHand: preparedData?.myHand ?? [],
+    fieldCardText: preparedData?.fieldCardText ?? "",
+    isDeckCards: preparedData?.isDeckCards ?? {},
+    rarityBonuses: preparedData?.rarityBonuses ?? {},
+    cardMap: preparedData?.cardMap ?? new Map(),
+    exchangeCards,
+    generateWord,
+    submitCard,
+    respondToDeclaration,
+    isActionLoading,
+  };
+}

--- a/features/battle/hooks/usePhaseTimer.ts
+++ b/features/battle/hooks/usePhaseTimer.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { PHASE_TIME_LIMITS } from "../types/phase";
+
+/**
+ * フェーズタイマーフック
+ * フェーズ開始時刻から残り時間を計算し、タイムアウト処理を行う
+ */
+export function usePhaseTimer(
+  phaseStartTime: number,
+  currentPhase: string,
+  onTimeout?: () => void
+) {
+  const [timeRemaining, setTimeRemaining] = useState<number>(0);
+
+  useEffect(() => {
+    // フェーズ開始時刻が更新されたら、残り時間をリセット
+    const timeLimit = PHASE_TIME_LIMITS[currentPhase as keyof typeof PHASE_TIME_LIMITS] ?? 0;
+    const elapsed = Math.floor((Date.now() - phaseStartTime) / 1000);
+    const remaining = Math.max(0, timeLimit - elapsed);
+    setTimeRemaining(remaining);
+
+    // 既にタイムアウトしている場合
+    if (remaining <= 0 && onTimeout) {
+      onTimeout();
+      return;
+    }
+
+    // 1秒ごとに残り時間を更新
+    const interval = setInterval(() => {
+      const newElapsed = Math.floor((Date.now() - phaseStartTime) / 1000);
+      const newRemaining = Math.max(0, timeLimit - newElapsed);
+      setTimeRemaining(newRemaining);
+
+      if (newRemaining <= 0 && onTimeout) {
+        onTimeout();
+      }
+    }, 1000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [phaseStartTime, currentPhase, onTimeout]);
+
+  return timeRemaining;
+}

--- a/features/battle/utils/battle-data.ts
+++ b/features/battle/utils/battle-data.ts
@@ -1,0 +1,212 @@
+import type { Doc, Id } from "../../../convex/_generated/dataModel";
+import type { Card } from "../../common/types/card";
+import { getRarityBonus } from "../../common/utils/rarity";
+import type { Battle } from "../types/battle";
+import type { PlayerState } from "../types/player";
+
+/**
+ * ConvexのバトルドキュメントをフロントエンドのBattle型に変換
+ * bigint型をnumber型に変換
+ */
+export function convertBattleDocToBattle(battleDoc: Doc<"battle">): Battle {
+  return {
+    ...battleDoc,
+    current_round: Number(battleDoc.current_round),
+    players: battleDoc.players.map((player) => ({
+      ...player,
+      score: Number(player.score),
+      turn_state: {
+        ...player.turn_state,
+        actions_remaining: Number(player.turn_state.actions_remaining),
+        deck_cards_remaining: Number(player.turn_state.deck_cards_remaining),
+      },
+    })),
+    round_results: battleDoc.round_results.map((result) => ({
+      ...result,
+      round_number: Number(result.round_number),
+      points_awarded: result.points_awarded.map((points) => ({
+        ...points,
+        points: Number(points.points),
+      })),
+    })),
+  };
+}
+
+/**
+ * ConvexのカードドキュメントをフロントエンドのCard型に変換
+ */
+export function convertCardDocToCard(cardDoc: Doc<"card">): Card {
+  return {
+    id: cardDoc._id,
+    name: cardDoc.text, // Convexでは`text`フィールド
+    rarity: cardDoc.rarity,
+    card_number: cardDoc.card_number,
+  };
+}
+
+/**
+ * カードIDの配列からCardオブジェクトの配列に変換
+ */
+export function convertCardIdsToCards(
+  cardIds: Id<"card">[],
+  cardMap: Map<Id<"card">, Doc<"card">>
+): Card[] {
+  return cardIds
+    .map((cardId) => {
+      const cardDoc = cardMap.get(cardId);
+      return cardDoc ? convertCardDocToCard(cardDoc) : null;
+    })
+    .filter((card): card is Card => card !== null);
+}
+
+/**
+ * カードIDの配列からCardオブジェクトのマップを作成
+ */
+export function createCardMap(cards: Doc<"card">[]): Map<Id<"card">, Doc<"card">> {
+  const cardMap = new Map<Id<"card">, Doc<"card">>();
+  for (const card of cards) {
+    cardMap.set(card._id, card);
+  }
+  return cardMap;
+}
+
+/**
+ * デッキカード判定マップを生成
+ * @param handCardIds 手札のカードID配列
+ * @param deckCardIds デッキに含まれるカードID配列
+ * @returns カードIDをキー、デッキカードかどうかを値とするマップ
+ */
+export function createDeckCardMap(
+  handCardIds: Id<"card">[],
+  deckCardIds: Id<"card">[]
+): Record<string, boolean> {
+  const deckCardSet = new Set(deckCardIds);
+  const result: Record<string, boolean> = {};
+  for (const cardId of handCardIds) {
+    result[cardId] = deckCardSet.has(cardId);
+  }
+  return result;
+}
+
+/**
+ * レアリティボーナスマップを生成
+ * @param handCardIds 手札のカードID配列
+ * @param cardMap カードドキュメントのマップ
+ * @param isDeckCards デッキカード判定マップ
+ * @returns カードIDをキー、レアリティボーナスを値とするマップ
+ */
+export function createRarityBonusMap(
+  handCardIds: Id<"card">[],
+  cardMap: Map<Id<"card">, Doc<"card">>,
+  isDeckCards: Record<string, boolean>
+): Record<string, number> {
+  const result: Record<string, number> = {};
+  for (const cardId of handCardIds) {
+    const cardDoc = cardMap.get(cardId);
+    const isDeckCard = isDeckCards[cardId] ?? false;
+    if (cardDoc && isDeckCard) {
+      result[cardId] = getRarityBonus(cardDoc.rarity);
+    } else {
+      result[cardId] = 0;
+    }
+  }
+  return result;
+}
+
+/**
+ * 自分のプレイヤー状態を取得
+ */
+export function getMyPlayerState(battle: Battle, myUserId: Id<"user">): PlayerState | undefined {
+  return battle.players.find((p) => p.user_id === myUserId);
+}
+
+/**
+ * 相手のプレイヤー状態を取得（2人対戦用）
+ */
+export function getOpponentPlayerState(
+  battle: Battle,
+  myUserId: Id<"user">
+): PlayerState | undefined {
+  return battle.players.find((p) => p.user_id !== myUserId);
+}
+
+/**
+ * お題カードのテキストを取得
+ */
+export function getFieldCardText(
+  fieldCardId: Id<"card">,
+  cardMap: Map<Id<"card">, Doc<"card">>
+): string {
+  const cardDoc = cardMap.get(fieldCardId);
+  return cardDoc?.text ?? "";
+}
+
+/**
+ * プレイヤーの手札をCardオブジェクトの配列に変換
+ */
+export function getPlayerHandCards(
+  playerState: PlayerState,
+  cardMap: Map<Id<"card">, Doc<"card">>
+): Card[] {
+  return convertCardIdsToCards(playerState.hand, cardMap);
+}
+
+/**
+ * バトルデータの準備（カード情報の取得と変換）
+ * この関数は実際のデータ取得処理を含むため、useBattleフックから呼び出される想定
+ */
+export interface PreparedBattleData {
+  /** 自分のプレイヤー状態 */
+  myPlayer: PlayerState;
+  /** 相手のプレイヤー状態 */
+  opponentPlayer: PlayerState;
+  /** 自分の手札 */
+  myHand: Card[];
+  /** お題カードのテキスト */
+  fieldCardText: string;
+  /** カードドキュメントのマップ */
+  cardMap: Map<Id<"card">, Doc<"card">>;
+  /** デッキカード判定マップ */
+  isDeckCards: Record<string, boolean>;
+  /** レアリティボーナスマップ */
+  rarityBonuses: Record<string, number>;
+}
+
+/**
+ * バトルデータを準備（カード情報の取得と変換）
+ * 注: この関数は実際のデータ取得処理は含まない。
+ * useBattleフックでカード情報を取得した後、この関数を使用してデータを変換する。
+ */
+export function prepareBattleData(
+  battle: Battle,
+  myUserId: Id<"user">,
+  cardDocs: Doc<"card">[]
+): PreparedBattleData | null {
+  const myPlayer = getMyPlayerState(battle, myUserId);
+  const opponentPlayer = getOpponentPlayerState(battle, myUserId);
+
+  if (!myPlayer || !opponentPlayer) {
+    return null;
+  }
+
+  const cardMap = createCardMap(cardDocs);
+  const myHand = getPlayerHandCards(myPlayer, cardMap);
+  const fieldCardText = getFieldCardText(battle.field_card_id, cardMap);
+
+  // デッキカード判定（デッキカードリストはbattleの情報から取得できないため、
+  // 別途デッキ情報を取得する必要がある。ここでは空の配列を仮定）
+  // TODO: 実際のデッキカードリストを取得する必要がある
+  const deckCardIds: Id<"card">[] = []; // 実際の実装ではデッキ情報から取得
+  const isDeckCards = createDeckCardMap(myPlayer.hand, deckCardIds);
+  const rarityBonuses = createRarityBonusMap(myPlayer.hand, cardMap, isDeckCards);
+
+  return {
+    myPlayer,
+    opponentPlayer,
+    myHand,
+    fieldCardText,
+    cardMap,
+    isDeckCards,
+    rarityBonuses,
+  };
+}

--- a/features/battle/utils/battle-data.ts
+++ b/features/battle/utils/battle-data.ts
@@ -153,7 +153,7 @@ export function getPlayerHandCards(
 
 /**
  * バトルデータの準備（カード情報の取得と変換）
- * この関数は実際のデータ取得処理を含むため、useBattleフックから呼び出される想定
+ * この型は useBattle.ts で使用されています。
  */
 export interface PreparedBattleData {
   /** 自分のプレイヤー状態 */
@@ -170,43 +170,4 @@ export interface PreparedBattleData {
   isDeckCards: Record<string, boolean>;
   /** レアリティボーナスマップ */
   rarityBonuses: Record<string, number>;
-}
-
-/**
- * バトルデータを準備（カード情報の取得と変換）
- * 注: この関数は実際のデータ取得処理は含まない。
- * useBattleフックでカード情報を取得した後、この関数を使用してデータを変換する。
- */
-export function prepareBattleData(
-  battle: Battle,
-  myUserId: Id<"user">,
-  cardDocs: Doc<"card">[]
-): PreparedBattleData | null {
-  const myPlayer = getMyPlayerState(battle, myUserId);
-  const opponentPlayer = getOpponentPlayerState(battle, myUserId);
-
-  if (!myPlayer || !opponentPlayer) {
-    return null;
-  }
-
-  const cardMap = createCardMap(cardDocs);
-  const myHand = getPlayerHandCards(myPlayer, cardMap);
-  const fieldCardText = getFieldCardText(battle.field_card_id, cardMap);
-
-  // デッキカード判定（デッキカードリストはbattleの情報から取得できないため、
-  // 別途デッキ情報を取得する必要がある。ここでは空の配列を仮定）
-  // TODO: 実際のデッキカードリストを取得する必要がある
-  const deckCardIds: Id<"card">[] = []; // 実際の実装ではデッキ情報から取得
-  const isDeckCards = createDeckCardMap(myPlayer.hand, deckCardIds);
-  const rarityBonuses = createRarityBonusMap(myPlayer.hand, cardMap, isDeckCards);
-
-  return {
-    myPlayer,
-    opponentPlayer,
-    myHand,
-    fieldCardText,
-    cardMap,
-    isDeckCards,
-    rarityBonuses,
-  };
 }

--- a/src/app/battle/[id]/page.tsx
+++ b/src/app/battle/[id]/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { api } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { BattleContainer } from "../../../../features/battle/components/BattleContainer";
+
+/**
+ * バトルページ
+ */
+export default function BattlePage() {
+  const params = useParams();
+  const router = useRouter();
+  const battleId = params.id as Id<"battle"> | undefined;
+
+  // 現在のユーザーを取得
+  const user = useQuery(api.user.getMyUser);
+
+  // 認証チェック
+  useEffect(() => {
+    if (user === null) {
+      router.push("/signin");
+    }
+  }, [user, router]);
+
+  // ローディング状態
+  if (user === undefined) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="text-xl mb-4">読み込み中...</div>
+          <div className="w-16 h-16 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto" />
+        </div>
+      </div>
+    );
+  }
+
+  // 認証されていない場合
+  if (!user) {
+    return null;
+  }
+
+  // バトルIDの検証
+  if (!battleId) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="text-xl mb-4 text-red-600">バトルIDが無効です</div>
+          <button
+            onClick={() => router.push("/")}
+            className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600"
+          >
+            ホームに戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return <BattleContainer battleId={battleId} myUserId={user._id} />;
+}


### PR DESCRIPTION
# Pull Request

## Issue

Closes #46 

## 概要

<!-- このPRで何を実装/修正したかを簡潔に説明してください -->

- 2人用対戦ページにてコンポーネント等を統合したページを作成しました

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- [x] 新機能の追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テストの追加/修正
- [ ] その他:

## 変更箇所

<!-- どの部分を変更したかチェックしてください -->

- [x] フロントエンド
- [x] バックエンド
- [ ] データベース
- [ ] 設定ファイル
- [ ] ドキュメント

## 注意事項

<!-- レビュー時に注意してほしい点や、デプロイ時の注意点があれば記載してください -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * バトルページとクライアント側バトル画面を追加し、指定IDで対戦可能に。
  * カード交換、ワード生成、カード提出、宣言への応答など対戦アクションをUIで実行可能に。
  * フェーズごとの残り時間表示と自動タイムアウトを導入し、フェーズ固有画面を切替表示。
  * バトル関連データの変換・準備処理を強化し、読み込み・エラー表示を改善。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->