### PR TITLE
手札にカードにお題との類似度プレビューが表示されるように

### DIFF
--- a/features/battle/components/BattleContainer.tsx
+++ b/features/battle/components/BattleContainer.tsx
@@ -44,6 +44,7 @@ export function BattleContainer({ battleId, myUserId }: BattleContainerProps) {
     fieldCardText,
     isDeckCards,
     rarityBonuses,
+    similarities,
     exchangeCards,
     generateWord,
     submitCard,
@@ -160,10 +161,6 @@ export function BattleContainer({ battleId, myUserId }: BattleContainerProps) {
   const currentPhase = battle.current_phase;
   const myScore = myPlayer.score;
   const opponentScore = opponentPlayer.score;
-
-  // 類似度マップ（提出フェーズで使用）
-  // TODO: 実際の類似度計算を実装
-  const similarities: Record<string, number> = {};
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-amber-50 to-amber-100">


### PR DESCRIPTION
# Pull Request

## Issue

Closes #48 

## 概要

<!-- このPRで何を実装/修正したかを簡潔に説明してください -->

- 手札のカードにお題との類似度プレビューが表示されるように修正を加えました。

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- [x] 新機能の追加
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] テストの追加/修正
- [ ] その他:

## 変更箇所

<!-- どの部分を変更したかチェックしてください -->

- [x] フロントエンド
- [x] バックエンド
- [ ] データベース
- [ ] 設定ファイル
- [ ] ドキュメント

## 注意事項

<!-- レビュー時に注意してほしい点や、デプロイ時の注意点があれば記載してください -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 単語提出フェーズ中に、手札のカードが場札とどの程度類似しているかをリアルタイムで確認できる相似度プレビュー機能を追加しました。各カードについてスコアで類似度が表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->