### PR TITLE
ルーム作成、参加ページの作成

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type * as card from "../card.js";
 import type * as deck from "../deck.js";
 import type * as http from "../http.js";
 import type * as market from "../market.js";
+import type * as room from "../room.js";
 import type * as user from "../user.js";
 
 import type {
@@ -35,6 +36,7 @@ declare const fullApi: ApiFromModules<{
   deck: typeof deck;
   http: typeof http;
   market: typeof market;
+  room: typeof room;
   user: typeof user;
 }>;
 declare const fullApiWithMounts: typeof fullApi;

--- a/convex/_generated/api.js
+++ b/convex/_generated/api.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * Generated `api` utility.
  *

--- a/convex/room.ts
+++ b/convex/room.ts
@@ -335,13 +335,10 @@ export const startBattle = mutation({
 
     // バトルを作成（createBattleを呼び出す）
     // ホストが両プレイヤーの一人として認証されているため、createBattleを直接呼び出す
-    const battleResult: { battleId: Id<"battle"> } = await ctx.runMutation(
-      api.battle.createBattle,
-      {
-        player_ids: room.players,
-        deck_ids: [deck1, deck2],
-      }
-    );
+    const battleResult = await ctx.runMutation(api.battle.createBattle, {
+      player_ids: room.players,
+      deck_ids: [deck1, deck2],
+    });
 
     // ルームを更新
     await ctx.db.patch(roomId, {

--- a/convex/room.ts
+++ b/convex/room.ts
@@ -1,0 +1,375 @@
+import { v } from "convex/values";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import { mutation, query } from "./_generated/server";
+import { getCurrentUser } from "./user";
+
+/**
+ * 現在の認証ユーザーを取得（認証されていない場合はエラー）
+ */
+async function getCurrentUserOrThrow(ctx: MutationCtx | QueryCtx): Promise<{ _id: Id<"user"> }> {
+  const user = await getCurrentUser(ctx);
+  if (!user) {
+    throw new Error("認証されていません。ログインしてください");
+  }
+  return user;
+}
+
+/**
+ * デッキ所有権を検証
+ */
+async function verifyDeckOwnership(
+  ctx: MutationCtx | QueryCtx,
+  deckId: Id<"deck">,
+  userId: Id<"user">
+): Promise<void> {
+  const deck = await ctx.db.get(deckId);
+  if (!deck) {
+    throw new Error("デッキが見つかりません");
+  }
+  if (deck.user_id !== userId) {
+    throw new Error("このデッキはあなたのものではありません");
+  }
+}
+
+/**
+ * ユニークなルームコードを生成（6桁の英数字）
+ */
+function generateRoomCode(): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  let code = "";
+  for (let i = 0; i < 6; i++) {
+    code += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return code;
+}
+
+/**
+ * ユニークなルームコードを生成（重複チェック付き）
+ */
+async function generateUniqueRoomCode(ctx: MutationCtx): Promise<string> {
+  let code: string;
+  let attempts = 0;
+  const maxAttempts = 10;
+
+  do {
+    code = generateRoomCode();
+    const existingRoom = await ctx.db
+      .query("game_room")
+      .withIndex("by_code", (q) => q.eq("room_code", code))
+      .first();
+
+    if (!existingRoom) {
+      return code;
+    }
+
+    attempts++;
+    if (attempts >= maxAttempts) {
+      throw new Error("ルームコードの生成に失敗しました。しばらくしてから再度お試しください");
+    }
+  } while (true);
+}
+
+/**
+ * ルームを作成
+ */
+export const createRoom = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const currentUser = await getCurrentUserOrThrow(ctx);
+
+    // 既にアクティブなルームに参加していないかチェック
+    const existingRoom = await ctx.db
+      .query("game_room")
+      .withIndex("by_host", (q) => q.eq("host_id", currentUser._id))
+      .filter((q) => q.eq(q.field("is_active"), false))
+      .first();
+
+    if (existingRoom) {
+      // 既存のルームがある場合はそれを返す
+      return { roomId: existingRoom._id, roomCode: existingRoom.room_code };
+    }
+
+    // 参加者として既にルームに参加していないかチェック
+    const joinedRoom = await ctx.db
+      .query("game_room")
+      .collect()
+      .then((rooms) => rooms.find((r) => r.players.includes(currentUser._id) && !r.is_active));
+
+    if (joinedRoom) {
+      return { roomId: joinedRoom._id, roomCode: joinedRoom.room_code };
+    }
+
+    // ルームコードを生成
+    const roomCode = await generateUniqueRoomCode(ctx);
+
+    // ルームを作成
+    const roomId = await ctx.db.insert("game_room", {
+      players: [currentUser._id],
+      room_code: roomCode,
+      host_id: currentUser._id,
+      is_active: false,
+      battle_id: undefined,
+      player_decks: undefined,
+    });
+
+    return { roomId, roomCode };
+  },
+});
+
+/**
+ * デッキを選択
+ */
+export const selectDeck = mutation({
+  args: {
+    roomId: v.id("game_room"),
+    deckId: v.id("deck"),
+  },
+  handler: async (ctx, { roomId, deckId }) => {
+    const currentUser = await getCurrentUserOrThrow(ctx);
+
+    const room = await ctx.db.get(roomId);
+    if (!room) {
+      throw new Error("ルームが見つかりません");
+    }
+
+    if (!room.players.includes(currentUser._id)) {
+      throw new Error("このルームに参加していません");
+    }
+
+    if (room.is_active) {
+      throw new Error("対戦中のルームではデッキを変更できません");
+    }
+
+    // デッキ所有権を検証
+    await verifyDeckOwnership(ctx, deckId, currentUser._id);
+
+    // デッキカード数を確認（最低5枚必要）
+    const deckCards = await ctx.db
+      .query("deck_card")
+      .withIndex("by_deck_id", (q) => q.eq("deck_id", deckId))
+      .collect();
+
+    if (deckCards.length < 5) {
+      throw new Error("デッキには最低5枚のカードが必要です");
+    }
+
+    // プレイヤーのデッキ選択を更新
+    const playerDecks = (room.player_decks as Record<string, Id<"deck">> | undefined) ?? {};
+    playerDecks[currentUser._id] = deckId;
+
+    await ctx.db.patch(roomId, {
+      player_decks: playerDecks,
+    });
+
+    return { success: true };
+  },
+});
+
+/**
+ * ルームに参加
+ */
+export const joinRoom = mutation({
+  args: {
+    roomCode: v.string(),
+  },
+  handler: async (ctx, { roomCode }) => {
+    const currentUser = await getCurrentUserOrThrow(ctx);
+
+    // ルームコードでルームを検索（大文字小文字を区別しない）
+    const room = await ctx.db
+      .query("game_room")
+      .withIndex("by_code", (q) => q.eq("room_code", roomCode.toUpperCase()))
+      .first();
+
+    if (!room) {
+      throw new Error("ルームが見つかりません");
+    }
+
+    if (room.is_active) {
+      throw new Error("このルームは既に対戦中です");
+    }
+
+    if (room.players.includes(currentUser._id)) {
+      // 既に参加している場合はそのまま返す
+      return { roomId: room._id, roomCode: room.room_code };
+    }
+
+    if (room.players.length >= 2) {
+      throw new Error("このルームは満員です");
+    }
+
+    // 参加者を追加
+    await ctx.db.patch(room._id, {
+      players: [...room.players, currentUser._id],
+    });
+
+    return { roomId: room._id, roomCode: room.room_code };
+  },
+});
+
+/**
+ * ルームから退出
+ */
+export const leaveRoom = mutation({
+  args: {
+    roomId: v.id("game_room"),
+  },
+  handler: async (ctx, { roomId }) => {
+    const currentUser = await getCurrentUserOrThrow(ctx);
+
+    const room = await ctx.db.get(roomId);
+    if (!room) {
+      throw new Error("ルームが見つかりません");
+    }
+
+    if (!room.players.includes(currentUser._id)) {
+      throw new Error("このルームに参加していません");
+    }
+
+    // ホストが退出する場合はルームを削除
+    if (room.host_id === currentUser._id) {
+      await ctx.db.delete(roomId);
+      return { success: true };
+    }
+
+    // 参加者が退出する場合は参加者リストから削除
+    const updatedPlayers = room.players.filter((id) => id !== currentUser._id);
+    await ctx.db.patch(roomId, {
+      players: updatedPlayers,
+    });
+
+    return { success: true };
+  },
+});
+
+/**
+ * ルーム情報を取得
+ */
+export const getRoom = query({
+  args: {
+    roomId: v.id("game_room"),
+  },
+  handler: async (ctx, { roomId }) => {
+    const currentUser = await getCurrentUserOrThrow(ctx);
+
+    const room = await ctx.db.get(roomId);
+    if (!room) {
+      return null;
+    }
+
+    // 参加者のみがルーム情報を取得可能
+    if (!room.players.includes(currentUser._id)) {
+      throw new Error("このルームに参加していません");
+    }
+
+    return room;
+  },
+});
+
+/**
+ * 自分のアクティブなルームを取得
+ */
+export const getMyRoom = query({
+  args: {},
+  handler: async (ctx) => {
+    const currentUser = await getCurrentUserOrThrow(ctx);
+
+    // ホストとしてのルームを検索
+    const hostRoom = await ctx.db
+      .query("game_room")
+      .withIndex("by_host", (q) => q.eq("host_id", currentUser._id))
+      .filter((q) => q.eq(q.field("is_active"), false))
+      .first();
+
+    if (hostRoom) {
+      return hostRoom;
+    }
+
+    // 参加者としてのルームを検索
+    const allRooms = await ctx.db.query("game_room").collect();
+    const joinedRoom = allRooms.find((r) => r.players.includes(currentUser._id) && !r.is_active);
+
+    return joinedRoom ?? null;
+  },
+});
+
+/**
+ * バトルを開始
+ */
+export const startBattle = mutation({
+  args: {
+    roomId: v.id("game_room"),
+  },
+  handler: async (ctx, { roomId }): Promise<{ battleId: Id<"battle"> }> => {
+    const currentUser = await getCurrentUserOrThrow(ctx);
+
+    const room = await ctx.db.get(roomId);
+    if (!room) {
+      throw new Error("ルームが見つかりません");
+    }
+
+    // ホストのみがバトルを開始可能
+    if (room.host_id !== currentUser._id) {
+      throw new Error("バトルを開始できるのはホストのみです");
+    }
+
+    if (room.is_active) {
+      throw new Error("このルームは既に対戦中です");
+    }
+
+    // 2人が参加していることを確認
+    if (room.players.length !== 2) {
+      throw new Error("バトルを開始するには2人が参加している必要があります");
+    }
+
+    // 各プレイヤーがデッキを選択していることを確認
+    const playerDecks = (room.player_decks as Record<string, Id<"deck">> | undefined) ?? {};
+    const deck1 = playerDecks[room.players[0]];
+    const deck2 = playerDecks[room.players[1]];
+
+    if (!deck1 || !deck2) {
+      throw new Error("全プレイヤーがデッキを選択する必要があります");
+    }
+
+    // バトルを作成（createBattleを呼び出す）
+    // ホストが両プレイヤーの一人として認証されているため、createBattleを直接呼び出す
+    const battleResult: { battleId: Id<"battle"> } = await ctx.runMutation(
+      api.battle.createBattle,
+      {
+        player_ids: room.players,
+        deck_ids: [deck1, deck2],
+      }
+    );
+
+    // ルームを更新
+    await ctx.db.patch(roomId, {
+      battle_id: battleResult.battleId,
+      is_active: true,
+    });
+
+    return { battleId: battleResult.battleId };
+  },
+});
+
+/**
+ * ルームコードでルームを検索
+ */
+export const getRoomByCode = query({
+  args: {
+    roomCode: v.string(),
+  },
+  handler: async (ctx, { roomCode }) => {
+    const room = await ctx.db
+      .query("game_room")
+      .withIndex("by_code", (q) => q.eq("room_code", roomCode.toUpperCase()))
+      .first();
+
+    if (!room) {
+      return null;
+    }
+
+    return room;
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -193,6 +193,7 @@ export default defineSchema({
     host_id: v.id("user"), // ルーム作成者
     is_active: v.boolean(), // 待機中か対戦中か
     battle_id: v.optional(v.id("battle")),
+    player_decks: v.optional(v.any()), // プレイヤーのデッキ選択 Record<userId, deckId>
   })
     .index("by_code", ["room_code"])
     .index("by_host", ["host_id"]),

--- a/src/app/battle/room/[id]/page.tsx
+++ b/src/app/battle/room/[id]/page.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useMutation, useQuery } from "convex/react";
+import { Check, Copy, Loader2, LogOut, Play, Users } from "lucide-react";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { api } from "../../../../../convex/_generated/api";
+import type { Id } from "../../../../../convex/_generated/dataModel";
+
+/**
+ * ルーム待機ページ
+ * 参加者が待機し、デッキを選択する
+ */
+export default function RoomWaitingPage() {
+  const params = useParams();
+  const router = useRouter();
+  const roomId = params.id as Id<"game_room"> | undefined;
+  const [selectedDeckId, setSelectedDeckId] = useState<Id<"deck"> | null>(null);
+  const [isLeaving, setIsLeaving] = useState(false);
+  const [isStarting, setIsStarting] = useState(false);
+  const [isSelectingDeck, setIsSelectingDeck] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const room = useQuery(api.room.getRoom, roomId ? { roomId } : "skip");
+  const user = useQuery(api.user.getMyUser);
+  const userDecks = useQuery(api.deck.getUserDecks);
+  const selectDeck = useMutation(api.room.selectDeck);
+  const leaveRoom = useMutation(api.room.leaveRoom);
+  const startBattle = useMutation(api.room.startBattle);
+
+  // 認証チェック
+  useEffect(() => {
+    if (user === null) {
+      router.push("/signin");
+    }
+  }, [user, router]);
+
+  // バトルIDが存在する場合はバトルページにリダイレクト
+  useEffect(() => {
+    if (room?.battle_id && room.is_active) {
+      router.push(`/battle/${room.battle_id}`);
+    }
+  }, [room, router]);
+
+  // ルームが見つからない場合
+  useEffect(() => {
+    if (room === null && user !== undefined) {
+      router.push("/game");
+    }
+  }, [room, user, router]);
+
+  // 選択済みデッキを設定
+  useEffect(() => {
+    if (room && user && room.player_decks) {
+      const playerDecks = room.player_decks as Record<string, Id<"deck">>;
+      const myDeckId = playerDecks[user._id];
+      if (myDeckId) {
+        setSelectedDeckId(myDeckId);
+      }
+    }
+  }, [room, user]);
+
+  // ローディング状態
+  if (user === undefined || room === undefined || userDecks === undefined) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="text-xl mb-4">読み込み中...</div>
+          <Loader2 className="w-8 h-8 animate-spin mx-auto" />
+        </div>
+      </div>
+    );
+  }
+
+  // 認証されていない場合
+  if (!user) {
+    return null;
+  }
+
+  // ルームが見つからない場合
+  if (!room) {
+    return null;
+  }
+
+  const isHost = room.host_id === user._id;
+  const playerDecks = (room.player_decks as Record<string, Id<"deck">> | undefined) ?? {};
+  const myDeckId = playerDecks[user._id];
+  const opponentId = room.players.find((id: Id<"user">) => id !== user._id);
+  const opponentDeckId = opponentId ? playerDecks[opponentId] : undefined;
+  const canStartBattle = isHost && room.players.length === 2 && myDeckId && opponentDeckId;
+
+  const handleCopyRoomCode = () => {
+    navigator.clipboard.writeText(room.room_code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleSelectDeck = async (deckId: Id<"deck">) => {
+    if (!roomId) return;
+
+    setIsSelectingDeck(true);
+    try {
+      await selectDeck({ roomId, deckId });
+      setSelectedDeckId(deckId);
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "デッキ選択に失敗しました");
+    } finally {
+      setIsSelectingDeck(false);
+    }
+  };
+
+  const handleStartBattle = async () => {
+    if (!roomId || !canStartBattle) return;
+
+    setIsStarting(true);
+    try {
+      const result = await startBattle({ roomId });
+      router.push(`/battle/${result.battleId}`);
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "バトル開始に失敗しました");
+      setIsStarting(false);
+    }
+  };
+
+  const handleLeaveRoom = async () => {
+    if (!roomId) return;
+
+    setIsLeaving(true);
+    try {
+      await leaveRoom({ roomId });
+      router.push("/game");
+    } catch (error) {
+      alert(error instanceof Error ? error.message : "ルーム退出に失敗しました");
+      setIsLeaving(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen p-6">
+      <div className="max-w-4xl mx-auto space-y-6">
+        {/* ヘッダー */}
+        <div className="text-center">
+          <h1 className="text-3xl font-bold mb-2">対戦ルーム</h1>
+          <div className="flex items-center justify-center gap-2">
+            <span className="text-gray-600 dark:text-gray-400">ルームコード:</span>
+            <code className="px-3 py-1 bg-gray-100 dark:bg-gray-800 rounded-md font-mono text-lg font-bold">
+              {room.room_code}
+            </code>
+            <button
+              onClick={handleCopyRoomCode}
+              className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
+              aria-label="ルームコードをコピー"
+            >
+              {copied ? <Check className="w-5 h-5 text-green-600" /> : <Copy className="w-5 h-5" />}
+            </button>
+          </div>
+        </div>
+
+        {/* 参加者情報 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="w-5 h-5" />
+              参加者
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {room.players.map((playerId: Id<"user">) => {
+                const isMe = playerId === user._id;
+                const hasSelectedDeck = !!playerDecks[playerId];
+                return (
+                  <div
+                    key={playerId}
+                    className={`flex items-center justify-between p-3 rounded-md ${
+                      isMe ? "bg-blue-50 dark:bg-blue-900/20" : "bg-gray-50 dark:bg-gray-800/50"
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">{isMe ? "あなた" : "相手"}</span>
+                      {isHost && playerId === room.host_id && (
+                        <span className="text-xs px-2 py-0.5 bg-yellow-100 dark:bg-yellow-900/30 rounded">
+                          ホスト
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {hasSelectedDeck ? (
+                        <span className="text-sm text-green-600 dark:text-green-400 flex items-center gap-1">
+                          <Check className="w-4 h-4" />
+                          デッキ選択済み
+                        </span>
+                      ) : (
+                        <span className="text-sm text-gray-500 dark:text-gray-400">
+                          デッキ選択待ち
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* デッキ選択 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>デッキを選択</CardTitle>
+            <CardDescription>使用するデッキを選択してください</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {userDecks.length === 0 ? (
+              <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                デッキがありません。デッキ編成ページでデッキを作成してください。
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {userDecks.map((deck: { _id: Id<"deck">; deck_name: string }) => (
+                  <button
+                    key={deck._id}
+                    onClick={() => handleSelectDeck(deck._id)}
+                    disabled={isSelectingDeck || selectedDeckId === deck._id}
+                    className={`p-4 border-2 rounded-lg text-left transition-all ${
+                      selectedDeckId === deck._id
+                        ? "border-blue-500 bg-blue-50 dark:bg-blue-900/20"
+                        : "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                    } disabled:opacity-50 disabled:cursor-not-allowed`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium">{deck.deck_name}</span>
+                      {selectedDeckId === deck._id && (
+                        <Check className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+                      )}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* アクション */}
+        <div className="flex items-center justify-center gap-4">
+          {isHost && canStartBattle && (
+            <Button
+              onClick={handleStartBattle}
+              disabled={isStarting || isLeaving}
+              size="lg"
+              className="min-w-[200px]"
+            >
+              {isStarting ? (
+                <>
+                  <Loader2 className="w-5 h-5 animate-spin mr-2" />
+                  開始中...
+                </>
+              ) : (
+                <>
+                  <Play className="w-5 h-5 mr-2" />
+                  バトル開始
+                </>
+              )}
+            </Button>
+          )}
+
+          {!isHost && (
+            <div className="text-center text-gray-500 dark:text-gray-400">
+              ホストがバトルを開始するのをお待ちください
+            </div>
+          )}
+
+          <Button
+            onClick={handleLeaveRoom}
+            disabled={isLeaving || isStarting}
+            variant="outline"
+            size="lg"
+          >
+            {isLeaving ? (
+              <>
+                <Loader2 className="w-5 h-5 animate-spin mr-2" />
+                退出中...
+              </>
+            ) : (
+              <>
+                <LogOut className="w-5 h-5 mr-2" />
+                退出
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useMutation, useQuery } from "convex/react";
+import { Loader2, Plus, Users } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { api } from "../../../convex/_generated/api";
+
+/**
+ * ゲーム開始ページ
+ * ルーム作成・参加のエントリーポイント
+ */
+export default function GamePage() {
+  const router = useRouter();
+  const [roomCode, setRoomCode] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [isJoining, setIsJoining] = useState(false);
+  const [joinError, setJoinError] = useState<string | null>(null);
+
+  const createRoom = useMutation(api.room.createRoom);
+  const joinRoom = useMutation(api.room.joinRoom);
+  const myRoom = useQuery(api.room.getMyRoom);
+  const user = useQuery(api.user.getMyUser);
+  const activeBattles = useQuery(
+    api.battle.getUserBattles,
+    user ? { userId: user._id } : "skip"
+  );
+
+  // アクティブなルームがある場合はリダイレクト
+  useEffect(() => {
+    if (myRoom) {
+      router.push(`/battle/room/${myRoom._id}`);
+    }
+  }, [myRoom, router]);
+
+  // アクティブなバトルがある場合はリダイレクト
+  useEffect(() => {
+    if (activeBattles && activeBattles.length > 0) {
+      const activeBattle = activeBattles.find((b) => b.game_status === "active");
+      if (activeBattle) {
+        router.push(`/battle/${activeBattle._id}`);
+      }
+    }
+  }, [activeBattles, router]);
+
+  // ローディング状態
+  if (user === undefined || myRoom === undefined) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="text-xl mb-4">読み込み中...</div>
+          <Loader2 className="w-8 h-8 animate-spin mx-auto" />
+        </div>
+      </div>
+    );
+  }
+
+  // 認証されていない場合
+  if (!user) {
+    router.push("/signin");
+    return null;
+  }
+
+  const handleCreateRoom = async () => {
+    setIsCreating(true);
+    setJoinError(null);
+    try {
+      const result = await createRoom();
+      router.push(`/battle/room/${result.roomId}`);
+    } catch (error) {
+      setJoinError(error instanceof Error ? error.message : "ルーム作成に失敗しました");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleJoinRoom = async () => {
+    if (!roomCode.trim()) {
+      setJoinError("ルームコードを入力してください");
+      return;
+    }
+
+    setIsJoining(true);
+    setJoinError(null);
+    try {
+      const result = await joinRoom({ roomCode: roomCode.trim().toUpperCase() });
+      router.push(`/battle/room/${result.roomId}`);
+    } catch (error) {
+      setJoinError(error instanceof Error ? error.message : "ルームに参加できませんでした");
+    } finally {
+      setIsJoining(false);
+    }
+  };
+
+  return (
+    <main className="flex items-center justify-center min-h-screen p-6">
+      <div className="w-full max-w-md space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold mb-2">ゲーム開始</h1>
+          <p className="text-gray-600 dark:text-gray-400">対戦を開始する方法を選択してください</p>
+        </div>
+
+        <div className="space-y-6">
+          {/* ルーム作成 */}
+          <div className="space-y-4">
+            <Button
+              onClick={handleCreateRoom}
+              disabled={isCreating || isJoining}
+              size="lg"
+              className="w-full"
+            >
+              {isCreating ? (
+                <>
+                  <Loader2 className="w-5 h-5 animate-spin mr-2" />
+                  作成中...
+                </>
+              ) : (
+                <>
+                  <Plus className="w-5 h-5 mr-2" />
+                  新しいルームを作成
+                </>
+              )}
+            </Button>
+          </div>
+
+          {/* 区切り線 */}
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-300 dark:border-gray-700" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-4 bg-white dark:bg-gray-900 text-gray-500 dark:text-gray-400">
+                または
+              </span>
+            </div>
+          </div>
+
+          {/* ルーム参加 */}
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="roomCode" className="text-sm font-medium">
+                ルームコードを入力
+              </label>
+              <Input
+                id="roomCode"
+                type="text"
+                placeholder="例: ABC123"
+                value={roomCode}
+                onChange={(e) => {
+                  setRoomCode(e.target.value.toUpperCase());
+                  setJoinError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    handleJoinRoom();
+                  }
+                }}
+                disabled={isCreating || isJoining}
+                className="text-center text-lg font-mono tracking-wider"
+                maxLength={6}
+              />
+            </div>
+
+            <Button
+              onClick={handleJoinRoom}
+              disabled={isCreating || isJoining || !roomCode.trim()}
+              size="lg"
+              variant="outline"
+              className="w-full"
+            >
+              {isJoining ? (
+                <>
+                  <Loader2 className="w-5 h-5 animate-spin mr-2" />
+                  参加中...
+                </>
+              ) : (
+                <>
+                  <Users className="w-5 h-5 mr-2" />
+                  ルームに参加
+                </>
+              )}
+            </Button>
+
+            {joinError && (
+              <div className="text-sm text-red-600 dark:text-red-400 text-center">
+                {joinError}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -23,10 +23,7 @@ export default function GamePage() {
   const joinRoom = useMutation(api.room.joinRoom);
   const myRoom = useQuery(api.room.getMyRoom);
   const user = useQuery(api.user.getMyUser);
-  const activeBattles = useQuery(
-    api.battle.getUserBattles,
-    user ? { userId: user._id } : "skip"
-  );
+  const activeBattles = useQuery(api.battle.getUserBattles, user ? { userId: user._id } : "skip");
 
   // アクティブなルームがある場合はリダイレクト
   useEffect(() => {
@@ -184,9 +181,7 @@ export default function GamePage() {
             </Button>
 
             {joinError && (
-              <div className="text-sm text-red-600 dark:text-red-400 text-center">
-                {joinError}
-              </div>
+              <div className="text-sm text-red-600 dark:text-red-400 text-center">{joinError}</div>
             )}
           </div>
         </div>
@@ -194,4 +189,3 @@ export default function GamePage() {
     </main>
   );
 }
-


### PR DESCRIPTION
# Pull Request

## Issue

Closes #39 

## 概要

<!-- このPRで何を実装/修正したかを簡潔に説明してください -->

- ルーム作成、参加ページを作成しました。二人が同じルームに参加することで、試合を始めることができます。
- 
## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- [x] 新機能の追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テストの追加/修正
- [ ] その他:

## 変更箇所

<!-- どの部分を変更したかチェックしてください -->

- [x] フロントエンド
- [ ] バックエンド
- [ ] データベース
- [ ] 設定ファイル
- [ ] ドキュメント

## 注意事項

<!-- レビュー時に注意してほしい点や、デプロイ時の注意点があれば記載してください -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ゲームルームの作成と参加機能を追加しました。ルームコードで他のプレイヤーと簡単にマッチングできます。
  * ルーム画面にてデッキ選択、参加プレイヤーの表示、ホストによるバトル開始機能を実装しました。
  * ゲーム開始からバトル待機までの一連のマッチングフローを統合しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->