### PR TITLE
敗北時のポイント減少をなくす

### DIFF
--- a/convex/battle.ts
+++ b/convex/battle.ts
@@ -380,12 +380,12 @@ function calculatePoints(
     if (score1 > score2) {
       return [
         { user_id: player1.user_id, points: 1n, reason: "normal_win" },
-        { user_id: player2.user_id, points: -1n, reason: "normal_lose" },
+        { user_id: player2.user_id, points: 0n, reason: "normal_lose" },
       ];
     }
     if (score2 > score1) {
       return [
-        { user_id: player1.user_id, points: -1n, reason: "normal_lose" },
+        { user_id: player1.user_id, points: 0n, reason: "normal_lose" },
         { user_id: player2.user_id, points: 1n, reason: "normal_win" },
       ];
     }


### PR DESCRIPTION
# Pull Request

## Issue

Closes #

## 概要

<!-- このPRで何を実装/修正したかを簡潔に説明してください -->

- 通常敗北時にポイントが-1減少していたをなくす

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- [ ] 新機能の追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テストの追加/修正
- [ ] その他:

## 変更箇所

<!-- どの部分を変更したかチェックしてください -->

- [ ] フロントエンド
- [x] バックエンド
- [ ] データベース
- [ ] 設定ファイル
- [ ] ドキュメント

## 注意事項

<!-- レビュー時に注意してほしい点や、デプロイ時の注意点があれば記載してください -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 試合スコア計算ロジックを改善し、勝敗が決まったラウンドにおいて敗者へのポイントペナルティを廃止しました。引き分けの場合は変更ありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->